### PR TITLE
Add Gate Layer (GT) reference to INK price reference data

### DIFF
--- a/src/components/dashboard/InkAprCalculator.tsx
+++ b/src/components/dashboard/InkAprCalculator.tsx
@@ -35,10 +35,11 @@ interface ReferencePoint {
 const REFERENCE_POINTS: ReferencePoint[] = [
   { id: 'zero', fdv: 0, position: 0 },
   { id: 'default', fdv: 1.0, position: 12, isDefault: true },
-  { id: 'okx', fdv: 2.1, position: 29.6, exchange: 'OKX', chain: 'X Layer', token: 'OKB', link: 'https://www.coingecko.com/en/coins/okb' },
-  { id: 'bitget', fdv: 3.2, position: 47.2, exchange: 'Bitget', chain: 'Morph', token: 'BGB', link: 'https://www.coingecko.com/en/coins/bitget-token' },
-  { id: 'bybit', fdv: 5.0, position: 64.8, exchange: 'Bybit', chain: 'Mantle', token: 'MNT', link: 'https://www.coingecko.com/en/coins/mantle' },
-  { id: 'cryptocom', fdv: 8.5, position: 82.4, exchange: 'Crypto.com', chain: 'Cronos', token: 'CRO', link: 'https://www.coingecko.com/en/coins/cronos' },
+  { id: 'okx', fdv: 2.1, position: 26.7, exchange: 'OKX', chain: 'X Layer', token: 'OKB', link: 'https://www.coingecko.com/en/coins/okb' },
+  { id: 'gate', fdv: 2.6, position: 41.3, exchange: 'Gate', chain: 'Gate Layer', token: 'GT', link: 'https://www.coingecko.com/en/coins/gatechain-token' },
+  { id: 'bitget', fdv: 3.2, position: 56.0, exchange: 'Bitget', chain: 'Morph', token: 'BGB', link: 'https://www.coingecko.com/en/coins/bitget-token' },
+  { id: 'bybit', fdv: 5.0, position: 70.7, exchange: 'Bybit', chain: 'Mantle', token: 'MNT', link: 'https://www.coingecko.com/en/coins/mantle' },
+  { id: 'cryptocom', fdv: 8.5, position: 85.3, exchange: 'Crypto.com', chain: 'Cronos', token: 'CRO', link: 'https://www.coingecko.com/en/coins/cronos' },
   { id: 'binance', fdv: 115.8, position: 100, exchange: 'Binance', chain: 'BSC', token: 'BNB', link: 'https://www.coingecko.com/en/coins/bnb' },
 ];
 

--- a/src/components/dashboard/TydroRateConfig.tsx
+++ b/src/components/dashboard/TydroRateConfig.tsx
@@ -62,6 +62,13 @@ const TydroRateConfig = ({
       link: 'https://www.coingecko.com/en/coins/mantle',
     },
     {
+      exchange: 'Gate',
+      chain: 'Gate Layer',
+      token: 'GT',
+      fdv: getFdvDisplay('GT'),
+      link: 'https://www.coingecko.com/en/coins/gatechain-token',
+    },
+    {
       exchange: 'Bitget',
       chain: 'Morph',
       token: 'BGB',


### PR DESCRIPTION
### Motivation
- Provide a Gate exchange reference point for the INK FDV/price UI so GT (Gate Token) is included in the FDV-based reference views and can use live CoinGecko FDV data.
- Keep the slider reference distribution visually meaningful by rebalancing positions after inserting the new point.

### Description
- Inserted a new `gate` reference into the INK slider reference list in `src/components/dashboard/InkAprCalculator.tsx` with `exchange: 'Gate'`, `chain: 'Gate Layer'`, `token: 'GT'`, `fdv: 2.6` and CoinGecko link `gatechain-token`, and adjusted neighboring `position` values to preserve even spacing.
- Added the same Gate/GT row to the compact reference table in `src/components/dashboard/TydroRateConfig.tsx` and wired it to use the `useCoingeckoFdv` display value (`getFdvDisplay('GT')`).
- Kept interpolation logic unchanged; only the reference points and displayed rows were updated.

### Testing
- Ran `npm run lint` and it completed successfully.
- Ran `npm run build` and the production build completed successfully.
- Started the dev server and captured a UI screenshot using Playwright to validate the new Gate/GT entry is rendered (artifact: `artifacts/ink-reference-gate.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69860d052ad8832c854250c77432a70e)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only reference-data changes (new token row + adjusted slider positions) with no changes to calculation/interpolation logic or backend interactions beyond existing CoinGecko lookups.
> 
> **Overview**
> Adds a new Gate reference point (Gate Layer / `GT`) to the INK FDV slider/reference data so the UI can display and update against live CoinGecko FDV for GT.
> 
> Rebalances the slider marker `position` values for the existing reference points and includes the Gate row in the compact reference table in `TydroRateConfig`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4e75614280a5352bb34e64133990d3e4e4cc46d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->