### PR TITLE
Gate GT INK reference

### DIFF
--- a/src/components/dashboard/InkAprCalculator.tsx
+++ b/src/components/dashboard/InkAprCalculator.tsx
@@ -35,10 +35,11 @@ interface ReferencePoint {
 const REFERENCE_POINTS: ReferencePoint[] = [
   { id: 'zero', fdv: 0, position: 0 },
   { id: 'default', fdv: 1.0, position: 12, isDefault: true },
-  { id: 'okx', fdv: 2.1, position: 29.6, exchange: 'OKX', chain: 'X Layer', token: 'OKB', link: 'https://www.coingecko.com/en/coins/okb' },
-  { id: 'bitget', fdv: 3.2, position: 47.2, exchange: 'Bitget', chain: 'Morph', token: 'BGB', link: 'https://www.coingecko.com/en/coins/bitget-token' },
-  { id: 'bybit', fdv: 5.0, position: 64.8, exchange: 'Bybit', chain: 'Mantle', token: 'MNT', link: 'https://www.coingecko.com/en/coins/mantle' },
-  { id: 'cryptocom', fdv: 8.5, position: 82.4, exchange: 'Crypto.com', chain: 'Cronos', token: 'CRO', link: 'https://www.coingecko.com/en/coins/cronos' },
+  { id: 'gate', fdv: 1.13, position: 26.7, exchange: 'Gate', chain: 'Gate Layer', token: 'GT', link: 'https://www.coingecko.com/en/coins/gatechain-token' },
+  { id: 'okx', fdv: 2.1, position: 41.3, exchange: 'OKX', chain: 'X Layer', token: 'OKB', link: 'https://www.coingecko.com/en/coins/okb' },
+  { id: 'bitget', fdv: 3.2, position: 56.0, exchange: 'Bitget', chain: 'Morph', token: 'BGB', link: 'https://www.coingecko.com/en/coins/bitget-token' },
+  { id: 'bybit', fdv: 5.0, position: 70.7, exchange: 'Bybit', chain: 'Mantle', token: 'MNT', link: 'https://www.coingecko.com/en/coins/mantle' },
+  { id: 'cryptocom', fdv: 8.5, position: 85.4, exchange: 'Crypto.com', chain: 'Cronos', token: 'CRO', link: 'https://www.coingecko.com/en/coins/cronos' },
   { id: 'binance', fdv: 115.8, position: 100, exchange: 'Binance', chain: 'BSC', token: 'BNB', link: 'https://www.coingecko.com/en/coins/bnb' },
 ];
 

--- a/src/components/dashboard/TydroRateConfig.tsx
+++ b/src/components/dashboard/TydroRateConfig.tsx
@@ -69,6 +69,13 @@ const TydroRateConfig = ({
       link: 'https://www.coingecko.com/en/coins/bitget-token',
     },
     {
+      exchange: 'Gate',
+      chain: 'Gate Layer',
+      token: 'GT',
+      fdv: getFdvDisplay('GT'),
+      link: 'https://www.coingecko.com/en/coins/gatechain-token',
+    },
+    {
       exchange: 'Binance',
       chain: 'BSC',
       token: 'BNB',


### PR DESCRIPTION
Add Gate Layer GT reference to the INK price calculator and reference table, including CoinGecko FDV and rebalancing slider positions.

---
Linear Issue: [AAV-8](https://linear.app/aaveapy/issue/AAV-8/加一个gate-layer到ink-price-reference，从coingecko获取fdv，token)

<p><a href="https://cursor.com/background-agent?bcId=bc-3cde0587-b3ac-4623-bf14-9a04b7077598"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3cde0587-b3ac-4623-bf14-9a04b7077598"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

