### PR TITLE
Add Gate Layer (GT) reference to INK FDV reference data

### DIFF
--- a/src/components/dashboard/InkAprCalculator.tsx
+++ b/src/components/dashboard/InkAprCalculator.tsx
@@ -35,10 +35,11 @@ interface ReferencePoint {
 const REFERENCE_POINTS: ReferencePoint[] = [
   { id: 'zero', fdv: 0, position: 0 },
   { id: 'default', fdv: 1.0, position: 12, isDefault: true },
-  { id: 'okx', fdv: 2.1, position: 29.6, exchange: 'OKX', chain: 'X Layer', token: 'OKB', link: 'https://www.coingecko.com/en/coins/okb' },
-  { id: 'bitget', fdv: 3.2, position: 47.2, exchange: 'Bitget', chain: 'Morph', token: 'BGB', link: 'https://www.coingecko.com/en/coins/bitget-token' },
-  { id: 'bybit', fdv: 5.0, position: 64.8, exchange: 'Bybit', chain: 'Mantle', token: 'MNT', link: 'https://www.coingecko.com/en/coins/mantle' },
-  { id: 'cryptocom', fdv: 8.5, position: 82.4, exchange: 'Crypto.com', chain: 'Cronos', token: 'CRO', link: 'https://www.coingecko.com/en/coins/cronos' },
+  { id: 'gate', fdv: 1.13, position: 26.7, exchange: 'Gate', chain: 'Gate Layer', token: 'GT', link: 'https://www.coingecko.com/en/coins/gatechain-token' },
+  { id: 'okx', fdv: 2.1, position: 41.3, exchange: 'OKX', chain: 'X Layer', token: 'OKB', link: 'https://www.coingecko.com/en/coins/okb' },
+  { id: 'bitget', fdv: 3.2, position: 56.0, exchange: 'Bitget', chain: 'Morph', token: 'BGB', link: 'https://www.coingecko.com/en/coins/bitget-token' },
+  { id: 'bybit', fdv: 5.0, position: 70.7, exchange: 'Bybit', chain: 'Mantle', token: 'MNT', link: 'https://www.coingecko.com/en/coins/mantle' },
+  { id: 'cryptocom', fdv: 8.5, position: 85.3, exchange: 'Crypto.com', chain: 'Cronos', token: 'CRO', link: 'https://www.coingecko.com/en/coins/cronos' },
   { id: 'binance', fdv: 115.8, position: 100, exchange: 'Binance', chain: 'BSC', token: 'BNB', link: 'https://www.coingecko.com/en/coins/bnb' },
 ];
 

--- a/src/components/dashboard/TydroRateConfig.tsx
+++ b/src/components/dashboard/TydroRateConfig.tsx
@@ -48,6 +48,13 @@ const TydroRateConfig = ({
       link: 'https://www.coingecko.com/en/coins/cronos',
     },
     {
+      exchange: 'Gate',
+      chain: 'Gate Layer',
+      token: 'GT',
+      fdv: getFdvDisplay('GT'),
+      link: 'https://www.coingecko.com/en/coins/gatechain-token',
+    },
+    {
       exchange: 'OKX',
       chain: 'X Layer',
       token: 'OKB',


### PR DESCRIPTION
### Motivation

- Add Gate / Gate Layer / GT as an additional FDV reference point for the INK price calculator so the UI can show Gate's FDV (sourced from CoinGecko) alongside existing exchange tokens.

### Description

- Inserted a new `gate` reference point into `REFERENCE_POINTS` in `src/components/dashboard/InkAprCalculator.tsx` with `exchange: 'Gate'`, `chain: 'Gate Layer'`, `token: 'GT'`, `link: 'https://www.coingecko.com/en/coins/gatechain-token'`, `fdv: 1.13`, and `position: 26.7`, and rebalanced subsequent marker positions to keep an even slider distribution.
- Updated `src/components/dashboard/TydroRateConfig.tsx` to add a matching compact reference row for `Gate / GT` that uses `getFdvDisplay('GT')` so live FDV will display when available from the existing `useCoingeckoFdv` feed.
- Continued to rely on the existing `useCoingeckoFdv` mapping which resolves FDV by token symbol (so `GT` will pick up CoinGecko data via the added CoinGecko link).
- Changes touch only UI reference data and positioning logic; interpolation functions (`fdvToPosition`/`positionToFdv`) were left unchanged and will operate over the new point set.

### Testing

- Ran `npm run lint` and it completed successfully.
- Ran `npm run build` (Vite production build) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698610d7edb0832cbaa4cf0da8001480)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only reference data update (adds one more marker/row and repositions slider points) with no changes to pricing/interpolation logic or data-fetching paths.
> 
> **Overview**
> Adds Gate/Gate Layer (`GT`) as an additional FDV reference shown in the INK APR calculator UI, sourcing the live FDV via the existing CoinGecko feed.
> 
> Updates `InkAprCalculator` reference-point data by inserting the new marker and rebalancing slider positions for subsequent points, and updates `TydroRateConfig` to display a matching reference row when FDV data is available.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 461885049a693e98be262635ee159ee8a8cc5180. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->