### PR TITLE
Add Gate Layer (GT) reference to INK price references

### DIFF
--- a/src/components/dashboard/InkAprCalculator.tsx
+++ b/src/components/dashboard/InkAprCalculator.tsx
@@ -35,10 +35,11 @@ interface ReferencePoint {
 const REFERENCE_POINTS: ReferencePoint[] = [
   { id: 'zero', fdv: 0, position: 0 },
   { id: 'default', fdv: 1.0, position: 12, isDefault: true },
-  { id: 'okx', fdv: 2.1, position: 29.6, exchange: 'OKX', chain: 'X Layer', token: 'OKB', link: 'https://www.coingecko.com/en/coins/okb' },
-  { id: 'bitget', fdv: 3.2, position: 47.2, exchange: 'Bitget', chain: 'Morph', token: 'BGB', link: 'https://www.coingecko.com/en/coins/bitget-token' },
-  { id: 'bybit', fdv: 5.0, position: 64.8, exchange: 'Bybit', chain: 'Mantle', token: 'MNT', link: 'https://www.coingecko.com/en/coins/mantle' },
-  { id: 'cryptocom', fdv: 8.5, position: 82.4, exchange: 'Crypto.com', chain: 'Cronos', token: 'CRO', link: 'https://www.coingecko.com/en/coins/cronos' },
+  { id: 'gate', fdv: 1.13, position: 26.7, exchange: 'Gate', chain: 'Gate Layer', token: 'GT', link: 'https://www.coingecko.com/en/coins/gatechain-token' },
+  { id: 'okx', fdv: 2.1, position: 41.3, exchange: 'OKX', chain: 'X Layer', token: 'OKB', link: 'https://www.coingecko.com/en/coins/okb' },
+  { id: 'bitget', fdv: 3.2, position: 56.0, exchange: 'Bitget', chain: 'Morph', token: 'BGB', link: 'https://www.coingecko.com/en/coins/bitget-token' },
+  { id: 'bybit', fdv: 5.0, position: 70.7, exchange: 'Bybit', chain: 'Mantle', token: 'MNT', link: 'https://www.coingecko.com/en/coins/mantle' },
+  { id: 'cryptocom', fdv: 8.5, position: 85.3, exchange: 'Crypto.com', chain: 'Cronos', token: 'CRO', link: 'https://www.coingecko.com/en/coins/cronos' },
   { id: 'binance', fdv: 115.8, position: 100, exchange: 'Binance', chain: 'BSC', token: 'BNB', link: 'https://www.coingecko.com/en/coins/bnb' },
 ];
 

--- a/src/components/dashboard/TydroRateConfig.tsx
+++ b/src/components/dashboard/TydroRateConfig.tsx
@@ -41,6 +41,13 @@ const TydroRateConfig = ({
 
   const referenceRows = [
     {
+      exchange: 'Gate',
+      chain: 'Gate Layer',
+      token: 'GT',
+      fdv: getFdvDisplay('GT'),
+      link: 'https://www.coingecko.com/en/coins/gatechain-token',
+    },
+    {
       exchange: 'Crypto.com',
       chain: 'Cronos',
       token: 'CRO',


### PR DESCRIPTION
### Motivation
- Surface Gate Layer / GT as an INK FDV reference so users can compare $INK price estimates against Gate's market FDV from CoinGecko.
- Keep both INK reference UIs consistent by adding Gate to the slider and the compact reference table.

### Description
- Added a `gate` reference point to `REFERENCE_POINTS` in `src/components/dashboard/InkAprCalculator.tsx` with `exchange: 'Gate'`, `chain: 'Gate Layer'`, `token: 'GT'`, `link: 'https://www.coingecko.com/en/coins/gatechain-token'`, initial `fdv: 1.13`, and position `26.7`, and rebalanced subsequent marker positions.
- Added a matching Gate/GT row to the compact reference table in `src/components/dashboard/TydroRateConfig.tsx` using `getFdvDisplay('GT')` so FDV will show when provided by `useCoingeckoFdv`.
- The implementation leverages the existing `useCoingeckoFdv` mapping-by-symbol so Gate's FDV will update dynamically like the other tokens.

### Testing
- Ran `npm run lint` and it completed successfully.
- Ran `npm run build` (Vite production build) and it completed successfully.
- Started the dev server and verified the page rendered via an automated Playwright screenshot, confirming the UI changes were visible.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986963b65c0832c8ae9ae52792eba5b)