### PR TITLE
cleanup: remove dead displayName parsing and fix drift-check job name

### DIFF
--- a/.github/workflows/hardcode-drift-check.yml
+++ b/.github/workflows/hardcode-drift-check.yml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 jobs:
-  check-hardcode-icons:
+  drift-checks:
     if: >
       github.event_name == 'workflow_dispatch' ||
       github.ref == format('refs/heads/{0}', github.event.repository.default_branch)

--- a/scripts/check-chain-icon-map-upstream.mjs
+++ b/scripts/check-chain-icon-map-upstream.mjs
@@ -76,7 +76,6 @@ function parseExpectedProdNetworks(networksConfigContent) {
       depth = 1;
       current = {
         name: null,
-        displayName: null,
         networkLogoPath: null,
       };
       continue;
@@ -85,9 +84,6 @@ function parseExpectedProdNetworks(networksConfigContent) {
     if (depth === 1) {
       const nameMatch = line.match(/^\s*name:\s*'([^']+)'/);
       if (nameMatch) current.name = nameMatch[1];
-
-      const displayNameMatch = line.match(/^\s*displayName:\s*'([^']+)'/);
-      if (displayNameMatch) current.displayName = displayNameMatch[1];
 
       const logoMatch = line.match(/^\s*networkLogoPath:\s*'([^']+)'/);
       if (logoMatch) current.networkLogoPath = logoMatch[1];


### PR DESCRIPTION
cleanup: remove dead displayName parsing and fix job name

- Remove unused `displayName` field parsing from `parseExpectedProdNetworks` (left over after alias removal)
- Rename workflow job from `check-hardcode-icons` to `drift-checks` to match actual scope

_This PR was generated with [Oz](https://www.warp.dev/oz)._
