### PR TITLE
fix(ci): auto-sync lock file for Lovable commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -24,12 +26,7 @@ jobs:
           cache: npm
       - name: Sync lock file (Lovable compat)
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            HEAD_AUTHOR=$(git log -1 --format='%an' ${{ github.event.pull_request.head.sha }})
-          else
-            HEAD_AUTHOR=$(git log -1 --format='%an')
-          fi
-          if [ "$HEAD_AUTHOR" = "gpt-engineer-app[bot]" ]; then
+          if [ "$(git log -1 --format='%an')" = "gpt-engineer-app[bot]" ]; then
             echo "Lovable commit detected – syncing lock file"
             npm install --package-lock-only
           fi
@@ -44,6 +41,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -51,12 +50,7 @@ jobs:
           cache: npm
       - name: Sync lock file (Lovable compat)
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            HEAD_AUTHOR=$(git log -1 --format='%an' ${{ github.event.pull_request.head.sha }})
-          else
-            HEAD_AUTHOR=$(git log -1 --format='%an')
-          fi
-          if [ "$HEAD_AUTHOR" = "gpt-engineer-app[bot]" ]; then
+          if [ "$(git log -1 --format='%an')" = "gpt-engineer-app[bot]" ]; then
             echo "Lovable commit detected – syncing lock file"
             npm install --package-lock-only
           fi


### PR DESCRIPTION
## What

Auto-sync `package-lock.json` for Lovable (`gpt-engineer-app[bot]`) commits in CI.

## Why

Lovable modifies `package.json` (e.g. adding new dependencies) but pushes without running `npm install`, leaving the lock file out of sync. This causes `npm ci` to fail on every Lovable commit.

## How

Added a step before `npm ci` in both `lint` and `build` jobs that:
1. Checks if the latest commit author is `gpt-engineer-app[bot]`
2. If yes, runs `npm install --package-lock-only` to regenerate the lock file (no `node_modules` changes)
3. Then `npm ci` proceeds as normal

Non-Lovable commits are unaffected — `npm ci` still enforces strict lock file consistency.

_This PR was generated with [Oz](https://www.warp.dev/oz)._
