### PR TITLE
Allow manual CI dispatch and trigger CI for token-icon-sync bot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - main

--- a/.github/workflows/token-icon-sync.yml
+++ b/.github/workflows/token-icon-sync.yml
@@ -9,6 +9,7 @@ on:
     - cron: "20 4 * * *"
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
 
@@ -35,6 +36,7 @@ jobs:
         run: npm run sync-token-icons
 
       - name: Create PR when icons changed
+        id: create_pr
         uses: peter-evans/create-pull-request@v7
         with:
           commit-message: "chore(icons): sync token icons"
@@ -47,3 +49,14 @@ jobs:
           labels: |
             automation
             assets
+
+      - name: Trigger CI for bot PR branch
+        if: steps.create_pr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl -sS -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            https://api.github.com/repos/${{ github.repository }}/actions/workflows/ci.yml/dispatches \
+            -d '{"ref":"bot/token-icon-sync"}'


### PR DESCRIPTION
### Motivation
- Enable manual runs of the CI workflow via `workflow_dispatch` for on-demand checks.
- Ensure the automated token icon sync can both create a bot PR and then trigger the CI workflow for the bot branch, which requires `actions: write` permission.

### Description
- Added `workflow_dispatch` to `.github/workflows/ci.yml` to allow manual dispatch of the CI workflow.
- In `.github/workflows/token-icon-sync.yml` added `actions: write` to `permissions` and set `id: create_pr` on the `create-pull-request` step.
- Added a step that posts to the GitHub Actions workflow dispatch API to trigger `ci.yml` for the `bot/token-icon-sync` branch when the PR is created by the bot.

### Testing
- No automated unit or integration tests were modified or executed as part of this workflow-only change.
- The workflow YAML was updated and will be validated by GitHub Actions on subsequent runs when the bot PR is created or the CI is manually dispatched.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69afef687fa48322b86a09f550092197)