### PR TITLE
fix(workflow): align hardcode sync and CI fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,16 +9,27 @@ on:
       - main
       - dev
       - feature/merkl-forecast
+  workflow_dispatch:
+    inputs:
+      target_ref:
+        description: "Ref (branch or SHA) to run CI against"
+        required: false
+        type: string
+  repository_dispatch:
+    types:
+      - ci-hardcode-sync
 
 jobs:
   lint:
     name: lint
     runs-on: ubuntu-latest
+    env:
+      CI_REF: ${{ github.event.pull_request.head.sha || github.event.client_payload.ref || github.event.inputs.target_ref || github.sha }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ env.CI_REF }}
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -38,11 +49,13 @@ jobs:
   build:
     name: build
     runs-on: ubuntu-latest
+    env:
+      CI_REF: ${{ github.event.pull_request.head.sha || github.event.client_payload.ref || github.event.inputs.target_ref || github.sha }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ env.CI_REF }}
       - name: Setup Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/hardcode-sync.yml
+++ b/.github/workflows/hardcode-sync.yml
@@ -111,7 +111,26 @@ jobs:
       - name: Warn when PAT is missing
         if: steps.cpr.outputs.pull-request-number != '' && env.HAS_HARDCODE_SYNC_PAT != 'true'
         run: |
-          echo "::warning::HARDCODE_SYNC_PAT is not configured. PR was created with GITHUB_TOKEN, so required CI checks (lint/build) may stay in 'Expected' state."
+          echo "::warning::HARDCODE_SYNC_PAT is not configured. PR was created with GITHUB_TOKEN, so pull_request CI may stay in 'Expected'. Fallback repository_dispatch CI will be triggered."
+
+      - name: Trigger fallback CI when PAT is missing
+        if: steps.cpr.outputs.pull-request-number != '' && env.HAS_HARDCODE_SYNC_PAT != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const ref = `${{ steps.cpr.outputs.pull-request-head-sha }}` || `${{ steps.cpr.outputs.pull-request-branch }}`;
+            await github.rest.repos.createDispatchEvent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event_type: 'ci-hardcode-sync',
+              client_payload: {
+                ref,
+                pr_number: `${{ steps.cpr.outputs.pull-request-number }}`,
+                source_workflow: 'hardcode-sync',
+                target_branch: process.env.TARGET_BRANCH
+              }
+            });
+            core.info(`Triggered fallback ci-hardcode-sync dispatch for ref: ${ref}`);
 
       - name: Create issue when verify still fails
         if: >
@@ -133,13 +152,32 @@ jobs:
               '',
               'Please inspect upstream drift and sync scripts.'
             ].join('\n');
-            await github.rest.issues.create({
+            const { data: issues } = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title,
-              body,
-              labels: ['automation', 'hardcode', 'drift']
+              state: 'open',
+              labels: 'automation,hardcode,drift',
+              per_page: 100
             });
+            const existing = issues.find((issue) => issue.title === title);
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body
+              });
+              core.info(`Appended failure details to existing issue #${existing.number}`);
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['automation', 'hardcode', 'drift']
+              });
+              core.info('Created a new hardcode verify failure issue');
+            }
 
       - name: Fail job when verify still fails
         if: >


### PR DESCRIPTION
## Why
- PR29 review pointed out issue dedupe regression in hardcode failure reporting
- Hardcode PRs can miss required lint/build when HARDCODE_SYNC_PAT is absent, which previously forced manual trigger

## What
- Restore dedupe behavior for hardcode verify failure issues (append comment to existing open issue)
- Add fallback CI dispatch from hardcode-sync when PAT is missing
- Extend CI workflow to accept  () and  with a target ref

## Result
- No manual link/build trigger needed when PAT is missing
- No repeated issue spam for persistent hardcode verify failures