### PR TITLE
fix(automerge): block merge until review threads are resolved

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -15,12 +15,51 @@ jobs:
       github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
+      - name: Cooldown for async review bots
+        run: sleep 180
+
       - name: Enable auto-merge when checks pass
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const pr = context.payload.pull_request;
+            const query = `
+              query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    id
+                    number
+                    reviewDecision
+                    autoMergeRequest {
+                      enabledAt
+                    }
+                    reviewThreads(first: 100) {
+                      nodes {
+                        isResolved
+                      }
+                    }
+                  }
+                }
+              }
+            `;
+            const data = await github.graphql(query, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              number: pr.number
+            });
+            const prInfo = data.repository.pullRequest;
+            const unresolvedThreads = prInfo.reviewThreads.nodes.filter((thread) => !thread.isResolved).length;
+            if (prInfo.reviewDecision === 'CHANGES_REQUESTED' || prInfo.reviewDecision === 'REVIEW_REQUIRED' || unresolvedThreads > 0) {
+              core.notice(
+                `Skip enabling auto-merge for PR #${pr.number}: reviewDecision=${prInfo.reviewDecision || 'NONE'}, unresolvedThreads=${unresolvedThreads}`
+              );
+              return;
+            }
+            if (prInfo.autoMergeRequest) {
+              core.info(`Auto-merge already enabled for PR #${pr.number}`);
+              return;
+            }
             await github.graphql(`
               mutation($pullRequestId: ID!) {
                 enablePullRequestAutoMerge(input: {
@@ -35,5 +74,5 @@ jobs:
                   }
                 }
               }
-            `, { pullRequestId: pr.node_id });
+            `, { pullRequestId: prInfo.id });
             core.info(`Enabled auto-merge for PR #${pr.number}`);


### PR DESCRIPTION
## Problem
Auto-merge currently enables as soon as label + checks are ready, without verifying unresolved review threads. This can merge before async review comments are handled.

## Changes
- Add a 3-minute cooldown to allow async review bots to post comments
- Query PR review state before enabling auto-merge
- Skip enabling auto-merge when:
  -  is  or 
  - unresolved review threads > 0
- Keep idempotency: if auto-merge already enabled, skip safely