### PR TITLE
fix(workflow): use workflow_dispatch for hardcode CI fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,16 +15,13 @@ on:
         description: "Ref (branch or SHA) to run CI against"
         required: false
         type: string
-  repository_dispatch:
-    types:
-      - ci-hardcode-sync
 
 jobs:
   lint:
     name: lint
     runs-on: ubuntu-latest
     env:
-      CI_REF: ${{ github.event.pull_request.head.sha || github.event.client_payload.ref || github.event.inputs.target_ref || github.sha }}
+      CI_REF: ${{ github.event.pull_request.head.sha || github.event.inputs.target_ref || github.sha }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -50,7 +47,7 @@ jobs:
     name: build
     runs-on: ubuntu-latest
     env:
-      CI_REF: ${{ github.event.pull_request.head.sha || github.event.client_payload.ref || github.event.inputs.target_ref || github.sha }}
+      CI_REF: ${{ github.event.pull_request.head.sha || github.event.inputs.target_ref || github.sha }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/hardcode-sync.yml
+++ b/.github/workflows/hardcode-sync.yml
@@ -14,6 +14,7 @@ on:
     - cron: "20 4 * * *"
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
   issues: write
@@ -111,26 +112,25 @@ jobs:
       - name: Warn when PAT is missing
         if: steps.cpr.outputs.pull-request-number != '' && env.HAS_HARDCODE_SYNC_PAT != 'true'
         run: |
-          echo "::warning::HARDCODE_SYNC_PAT is not configured. PR was created with GITHUB_TOKEN, so pull_request CI may stay in 'Expected'. Fallback repository_dispatch CI will be triggered."
+          echo "::warning::HARDCODE_SYNC_PAT is not configured. PR was created with GITHUB_TOKEN, so pull_request CI may stay in 'Expected'. Fallback workflow_dispatch CI will be triggered on the PR branch."
 
       - name: Trigger fallback CI when PAT is missing
         if: steps.cpr.outputs.pull-request-number != '' && env.HAS_HARDCODE_SYNC_PAT != 'true'
         uses: actions/github-script@v7
         with:
           script: |
-            const ref = `${{ steps.cpr.outputs.pull-request-head-sha }}` || `${{ steps.cpr.outputs.pull-request-branch }}`;
-            await github.rest.repos.createDispatchEvent({
+            const workflowRef = `${{ steps.cpr.outputs.pull-request-branch }}` || 'bot/hardcode-sync';
+            const targetRef = `${{ steps.cpr.outputs.pull-request-head-sha }}` || workflowRef;
+            await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              event_type: 'ci-hardcode-sync',
-              client_payload: {
-                ref,
-                pr_number: `${{ steps.cpr.outputs.pull-request-number }}`,
-                source_workflow: 'hardcode-sync',
-                target_branch: process.env.TARGET_BRANCH
+              workflow_id: 'ci.yml',
+              ref: workflowRef,
+              inputs: {
+                target_ref: targetRef
               }
             });
-            core.info(`Triggered fallback ci-hardcode-sync dispatch for ref: ${ref}`);
+            core.info(`Triggered fallback workflow_dispatch for ci.yml on ref ${workflowRef}, target_ref ${targetRef}`);
 
       - name: Create issue when verify still fails
         if: >


### PR DESCRIPTION
## Problem
PR32 fallback CI used repository_dispatch. That can run in default-branch workflow context, which may not satisfy required PR checks on the PR head SHA.

## Fix
- Switch fallback trigger to actions.createWorkflowDispatch for ci.yml
- Dispatch on PR branch ref and pass target_ref as PR head SHA
- Add actions:write permission in hardcode-sync workflow for workflow dispatch
- Remove repository_dispatch fallback path from ci.yml

## Expected result
When HARDCODE_SYNC_PAT is missing, hardcode-sync still triggers lint/build on the PR ref via workflow_dispatch, reducing Expected-check deadlocks.
