### PR TITLE
Add simulation disclaimer to PortfolioSummaryCard (AAV-615)

### DIFF
--- a/docs/adr/0010-portfolio-panel-disclaimer-placement.md
+++ b/docs/adr/0010-portfolio-panel-disclaimer-placement.md
@@ -1,0 +1,31 @@
+# ADR-0010: Portfolio Panel Disclaimer Placement
+
+## Status
+Accepted
+
+## Context
+The application already displays a simulation disclaimer inside each expanded
+reserve row (`SimulationSubRow`). Users who only look at the portfolio-level
+summary card never see that disclaimer, yet the summary metrics are equally
+derived from simulated data.
+
+## Decision
+Place the simulation disclaimer **inside `PortfolioSummaryCard`**, below the
+4-cell metric grid and before the card's closing wrapper. This keeps the
+disclaimer visually bound to the card that contains the simulated values without
+adding extra rows or wrappers to the parent `PortfolioPanel` layout.
+
+Key constraints:
+- Copy mirrors `SimulationSubRow` exactly (desktop / mobile variants via
+  `useIsMobile()`).
+- Styled `ds-text-10 text-muted-foreground/70 italic` — smaller and lighter
+  than the metric cells so it reads as supplementary.
+- No top margin (`mt-0`) — the disclaimer sits flush against the card's bottom
+  border to avoid inflating the card's visual height.
+- No structural changes to `PortfolioPanel`'s own grid/flex layout.
+
+## Consequences
+- Users see the disclaimer at the portfolio level without expanding any reserve.
+- The card grows by one line of 10 px text; negligible height impact.
+- If the disclaimer copy changes in `SimulationSubRow`, it must be updated here
+  as well (or extracted to a shared constant).

--- a/src/components/dashboard/PortfolioSummaryCard.test.tsx
+++ b/src/components/dashboard/PortfolioSummaryCard.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import PortfolioSummaryCard, { type PortfolioSummary } from './PortfolioSummaryCard';
+
+const summary: PortfolioSummary = {
+  totalSupplyUsd: 50_000,
+  totalBorrowUsd: 20_000,
+  netApy: 3.45,
+  dailyEarningsUsd: 4.72,
+};
+
+describe('PortfolioSummaryCard', () => {
+  it('renders the simulation disclaimer when summary is present', () => {
+    const html = renderToString(<PortfolioSummaryCard summary={summary} />);
+    // Desktop copy is the default for SSR (useIsMobile returns false)
+    expect(html).toContain(
+      'Simulation is for reference only. Final result depends on on-chain execution.',
+    );
+  });
+
+  it('renders all four metric cells', () => {
+    const html = renderToString(<PortfolioSummaryCard summary={summary} />);
+    expect(html).toContain('Total Supply');
+    expect(html).toContain('Total Borrow');
+    expect(html).toContain('Net APY');
+    expect(html).toContain('Daily Earnings');
+  });
+
+  it('returns null when summary is null', () => {
+    const html = renderToString(<PortfolioSummaryCard summary={null} />);
+    expect(html).toBe('');
+  });
+});

--- a/src/components/dashboard/PortfolioSummaryCard.tsx
+++ b/src/components/dashboard/PortfolioSummaryCard.tsx
@@ -1,0 +1,62 @@
+import { useIsMobile } from '@/hooks/use-mobile';
+
+/** Aggregated portfolio metrics passed from the parent panel. */
+export interface PortfolioSummary {
+  totalSupplyUsd: number;
+  totalBorrowUsd: number;
+  netApy: number;
+  dailyEarningsUsd: number;
+}
+
+interface PortfolioSummaryCardProps {
+  summary: PortfolioSummary | null;
+}
+
+function formatUsdCompact(value: number): string {
+  if (Math.abs(value) >= 1_000_000) return `$${(value / 1_000_000).toFixed(2)}M`;
+  if (Math.abs(value) >= 1_000) return `$${(value / 1_000).toFixed(2)}K`;
+  return `$${value.toFixed(2)}`;
+}
+
+function formatPercent(value: number): string {
+  return `${value.toFixed(2)}%`;
+}
+
+const PortfolioSummaryCard = ({ summary }: PortfolioSummaryCardProps) => {
+  const isMobile = useIsMobile();
+
+  if (!summary) return null;
+
+  return (
+    <div className="rounded-xl border border-border/50 bg-card p-4">
+      {/* 4-cell metric grid */}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4 sm:gap-4">
+        <div className="min-w-0">
+          <p className="ds-text-11 text-muted-foreground">Total Supply</p>
+          <p className="ds-text-14 font-semibold tabular-nums">{formatUsdCompact(summary.totalSupplyUsd)}</p>
+        </div>
+        <div className="min-w-0">
+          <p className="ds-text-11 text-muted-foreground">Total Borrow</p>
+          <p className="ds-text-14 font-semibold tabular-nums">{formatUsdCompact(summary.totalBorrowUsd)}</p>
+        </div>
+        <div className="min-w-0">
+          <p className="ds-text-11 text-muted-foreground">Net APY</p>
+          <p className="ds-text-14 font-semibold tabular-nums">{formatPercent(summary.netApy)}</p>
+        </div>
+        <div className="min-w-0">
+          <p className="ds-text-11 text-muted-foreground">Daily Earnings</p>
+          <p className="ds-text-14 font-semibold tabular-nums">{formatUsdCompact(summary.dailyEarningsUsd)}</p>
+        </div>
+      </div>
+
+      {/* Simulation disclaimer — flush against card bottom border (no mt) */}
+      <p className="ds-text-10 text-muted-foreground/70 italic">
+        {isMobile
+          ? 'Simulation only; final result is on-chain.'
+          : 'Simulation is for reference only. Final result depends on on-chain execution.'}
+      </p>
+    </div>
+  );
+};
+
+export default PortfolioSummaryCard;


### PR DESCRIPTION
## Summary

Add a simulation disclaimer to `PortfolioSummaryCard` so users who don't expand individual Reserve rows still see that the metrics are simulated estimates (AAV-615, parent AAV-561).

## Changes

- **`src/components/dashboard/PortfolioSummaryCard.tsx`** — New component with a 4-cell metric grid (Total Supply, Total Borrow, Net APY, Daily Earnings) and a simulation disclaimer rendered at the card bottom.
  - Desktop: `Simulation is for reference only. Final result depends on on-chain execution.`
  - Mobile: `Simulation only; final result is on-chain.` (via `useIsMobile()`)
  - Styling: `ds-text-10 text-muted-foreground/70 italic`, flush against card bottom border
- **`src/components/dashboard/PortfolioSummaryCard.test.tsx`** — Tests verifying disclaimer renders with summary, all four metric cells render, and null summary returns nothing.
- **`docs/adr/0010-portfolio-panel-disclaimer-placement.md`** — ADR documenting the placement decision.
- Prototype files created and deleted per acceptance criteria.

## Verification

`npm run lint && npm test && npm run build && npx tsc --noEmit` — all pass.

---

_Conversation: https://app.warp.dev/conversation/197e5d94-c40c-4af2-bd83-bb424e47d47b_
_Run: https://oz.warp.dev/runs/019ea0c5-3781-7544-8946-443baf720971_

_This PR was generated with [Oz](https://warp.dev/oz)._
