### PR TITLE
chore: upgrade @aave-dao/aave-address-book to ^4.52.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@aave-dao/aave-address-book": "^4.52.8",
         "@bgd-labs/aave-address-book": "^4.38.0",
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-accordion": "^1.2.11",
@@ -92,6 +93,18 @@
         "typescript-eslint": "^8.57.1",
         "vite": "^7.3.2",
         "vitest": "^4.1.0"
+      }
+    },
+    "node_modules/@aave-dao/aave-address-book": {
+      "version": "4.52.8",
+      "resolved": "https://registry.npmjs.org/@aave-dao/aave-address-book/-/aave-address-book-4.52.8.tgz",
+      "integrity": "sha512-EjsghtHg8Mtwh0XcToUBu9pyB/atX/FzNqw6n7feCikVBxsA5ZguPqMp8vqavxzDrBdik9xHeIOBcWsknNb7aw==",
+      "license": "MIT",
+      "workspaces": [
+        "ui"
+      ],
+      "peerDependencies": {
+        "viem": "^2.23.5"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "check:react-singleton": "node scripts/check-react-singleton.mjs"
   },
   "dependencies": {
+    "@aave-dao/aave-address-book": "^4.52.8",
     "@bgd-labs/aave-address-book": "^4.38.0",
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-accordion": "^1.2.11",


### PR DESCRIPTION
## Summary
- Upgrade `@aave-dao/aave-address-book` from `^4.38.0` to `^4.52.8`

## Root Cause
Issue #313: `package-lock.json` locked `@aave-dao/aave-address-book` at 4.38.0, which does not include `AaveV3EthereumHorizon`. The sync script evals `reservePatches.ts` via `Function()`, causing `ReferenceError: AaveV3EthereumHorizon is not defined` in CI.

## Fix
Updating the lockfile so CI installs a version that includes all market exports (Horizon, etc.). No manual hardcode sync needed.

Closes #313