### PR TITLE
fix(hardcode-sync): migrate @bgd-labs/aave-address-book to @aave-dao and auto-sync imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "license": "MIT",
       "dependencies": {
         "@aave-dao/aave-address-book": "^4.52.8",
-        "@bgd-labs/aave-address-book": "^4.38.0",
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-accordion": "^1.2.11",
         "@radix-ui/react-alert-dialog": "^1.1.14",
@@ -324,16 +323,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@bgd-labs/aave-address-book": {
-      "version": "4.44.22",
-      "license": "MIT",
-      "workspaces": [
-        "ui"
-      ],
-      "peerDependencies": {
-        "viem": "^2.23.5"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
   },
   "dependencies": {
     "@aave-dao/aave-address-book": "^4.52.8",
-    "@bgd-labs/aave-address-book": "^4.38.0",
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-alert-dialog": "^1.1.14",

--- a/scripts/lib/token-icon-symbols.mjs
+++ b/scripts/lib/token-icon-symbols.mjs
@@ -92,7 +92,7 @@ function extractAssignedObjectLiteral(content, marker) {
 
 function parseNamedAddressBookImports(reservePatchesContent) {
   const importMatch = reservePatchesContent.match(
-    /import\s*\{([\s\S]*?)\}\s*from\s*['"]@bgd-labs\/aave-address-book['"]/m
+    /import\s*\{([\s\S]*?)\}\s*from\s*['"]@aave-dao\/aave-address-book['"]/m
   );
   if (!importMatch) return [];
 

--- a/scripts/lib/token-icon-symbols.test.ts
+++ b/scripts/lib/token-icon-symbols.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import fs from 'fs';
 import path from 'path';
-import * as addressBook from '@bgd-labs/aave-address-book';
+import * as addressBook from '@aave-dao/aave-address-book';
 import { collectIconSymbolLogoHints, collectRequiredIconSymbols } from './token-icon-symbols.mjs';
 
 const reservePatchesPath = path.resolve(process.cwd(), 'src/ui-config/reservePatches.ts');

--- a/scripts/sync-reserve-patches-upstream.mjs
+++ b/scripts/sync-reserve-patches-upstream.mjs
@@ -188,6 +188,48 @@ function alignEntryIndent(entry) {
     .join('\n');
 }
 
+/**
+ * Extract address-book namespace names (e.g. AaveV3EthereumHorizon) used as
+ * computed keys `[Namespace.ASSETS.XXX.UNDERLYING.toLowerCase()]` in the file,
+ * and inject missing names into the `@aave-dao/aave-address-book` import.
+ */
+function injectMissingAddressBookImports(content) {
+  // All namespace names referenced in computed keys
+  const usedNames = new Set();
+  const keyRe = /\[([A-Za-z0-9_]+)\.ASSETS\./g;
+  let m;
+  while ((m = keyRe.exec(content)) !== null) {
+    usedNames.add(m[1]);
+  }
+
+  if (usedNames.size === 0) {
+    return { content, changed: false, addedNames: [] };
+  }
+
+  // Parse existing import (support both @aave-dao and @bgd-labs)
+  const importRe = /import\s*\{([\s\S]*?)\}\s*from\s*['"]@(aave-dao|bgd-labs)\/aave-address-book['"]/m;
+  const importMatch = content.match(importRe);
+  if (!importMatch) return { content, changed: false, addedNames: [] };
+
+  const existingNames = importMatch[1]
+    .split(',')
+    .map((n) => n.trim())
+    .filter(Boolean)
+    .map((n) => n.replace(/\s+as\s+[A-Za-z0-9_]+$/, '').trim())
+    .filter(Boolean);
+
+  const missing = [...usedNames].filter((n) => !existingNames.includes(n));
+  if (missing.length === 0) {
+    return { content, changed: false, addedNames: [] };
+  }
+
+  // Rebuild import with new names inserted, always normalize to @aave-dao
+  const fullImport = [...existingNames, ...missing].sort().join(',\n  ');
+  const newImportStmt = `import {\n  ${fullImport},\n} from '@aave-dao/aave-address-book'`;
+  const next = content.slice(0, importMatch.index) + newImportStmt + content.slice(importMatch.index + importMatch[0].length);
+  return { content: next, changed: true, addedNames: missing };
+}
+
 function applyUnderlyingAssetMapMerge(localContent, upstreamContent) {
   const localBounds = findUnderlyingAssetMapBounds(localContent);
   const upstreamBounds = findUnderlyingAssetMapBounds(upstreamContent);
@@ -243,7 +285,14 @@ async function main() {
     notes.push(`underlyingAssetMap: added ${underlyingMerge.addedCount} missing entr(y/ies)`);
   }
 
-  if (!symbolMerge.changed && !underlyingMerge.changed) {
+  // Auto-inject any new address-book namespace imports referenced in underlyingAssetMap
+  const importUpdate = injectMissingAddressBookImports(next);
+  if (importUpdate.changed) {
+    next = importUpdate.content;
+    notes.push(`address-book import: added ${importUpdate.addedNames.join(', ')}`);
+  }
+
+  if (!symbolMerge.changed && !underlyingMerge.changed && !importUpdate.changed) {
     console.log('reservePatches is already aligned (SYMBOL_MAP + underlyingAssetMap).');
     return;
   }

--- a/scripts/sync-token-icons.mjs
+++ b/scripts/sync-token-icons.mjs
@@ -25,7 +25,7 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import * as addressBook from '@bgd-labs/aave-address-book';
+import * as addressBook from '@aave-dao/aave-address-book';
 import {
   DEFAULT_PRODUCTION_API_BASE,
   DEFAULT_STAGING_API_BASE,

--- a/src/lib/tokenPriceResolver.ts
+++ b/src/lib/tokenPriceResolver.ts
@@ -37,6 +37,8 @@ const HARDCODED_PLATFORM_BY_CHAIN_ID: Record<number, string> = {
   196: 'x-layer',
   250: 'fantom',
   324: 'zksync',
+  1088: 'metis-andromeda',
+  1868: 'soneium',
   4326: 'megaeth',
   5000: 'mantle',
   8453: 'base',

--- a/src/ui-config/reservePatches.ts
+++ b/src/ui-config/reservePatches.ts
@@ -1,12 +1,13 @@
 import {
   AaveV3Arbitrum,
   AaveV3Ethereum,
+  AaveV3EthereumHorizon,
   AaveV3Gnosis,
   AaveV3Optimism,
   AaveV3Plasma,
   AaveV3Polygon,
-} from '@bgd-labs/aave-address-book';
-import tokenlist from '@bgd-labs/aave-address-book/tokenlist';
+} from '@aave-dao/aave-address-book';
+import tokenlist from '@aave-dao/aave-address-book/tokenlist';
 import { unPrefixSymbol } from '@/lib/tokenUtils';
 
 /**
@@ -305,6 +306,16 @@ export function fetchIconSymbolAndName({ underlyingAsset, symbol, name }: IconSy
       iconSymbol: 'FBTC',
       name: 'Function Bitcoin',
       symbol: 'FBTC',
+    },
+    [AaveV3EthereumHorizon.ASSETS.USCC.UNDERLYING.toLowerCase()]: {
+      symbol: 'USCC',
+      name: 'Bitwise Crypto Carry Fund',
+      iconSymbol: 'uscc',
+    },
+    [AaveV3EthereumHorizon.ASSETS.USTB.UNDERLYING.toLowerCase()]: {
+      symbol: 'USTB',
+      name: 'Invesco Short Duration US Government Securities Fund',
+      iconSymbol: 'ustb',
     },
 };
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -115,7 +115,7 @@ export default defineConfig(({ mode }) => ({
               return 'vendor-date';
             }
             // Aave protocol
-            if (id.includes('@bgd-labs')) {
+            if (id.includes('@aave-dao')) {
               return 'vendor-aave';
             }
             // UI libraries


### PR DESCRIPTION
## Problem

Hardcode Sync CI failing on main because `scripts/sync-token-icons.mjs` imports `@bgd-labs/aave-address-book`, which is the old package name. `npm ci` skips it due to workspace conflicts, causing `ERR_MODULE_NOT_FOUND`.

## Changes

1. **Import migration**: Replace `@bgd-labs/aave-address-book` → `@aave-dao/aave-address-book` in:
   - `scripts/sync-token-icons.mjs`
   - `src/ui-config/reservePatches.ts`
   - `scripts/lib/token-icon-symbols.test.ts`

2. **Regex fix**: Update `parseNamedAddressBookImports` in `scripts/lib/token-icon-symbols.mjs` to match the new package name.

3. **Auto-import injection**: Add `injectMissingAddressBookImports` to `scripts/sync-reserve-patches-upstream.mjs` — when upstream adds new address-book namespace references (e.g. `AaveV3EthereumHorizon`) to `underlyingAssetMap`, the sync script now automatically injects the missing import names.

4. **Dependency cleanup**: Remove unused `@bgd-labs/aave-address-book` from `package.json`.

## Verification

- `npm run hardcode:sync` passes
- `npm run hardcode:verify` passes
