### PR TITLE
chore: enable Dependabot security PRs with automerge for npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,19 @@
-# npm：保持 open-pull-requests-limit: 0，不自动开「有新版本」的依赖 PR（与 AGENTS.md 一致）。
-# github-actions：Workflow 内第三方 action 已钉到 commit SHA；此处 limit>0 以便 Dependabot
-# 在周更中提出 SHA / 版本 bump PR，避免长期停在过期 action。
-# Security updates 仍可在 Repo → Settings → Code security 中单独启用。
 version: 2
 updates:
   - package-ecosystem: npm
     directory: "/"
     schedule:
       interval: weekly
-    open-pull-requests-limit: 0
+    open-pull-requests-limit: 5
+    labels:
+      - automerge
+      - dependencies
 
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    labels:
+      - automerge
+      - dependencies

--- a/src/hooks/useRateSimulation.ts
+++ b/src/hooks/useRateSimulation.ts
@@ -38,6 +38,11 @@ import {
   ceilingEffectToSimulationFields,
 } from '@/lib/incentiveCeilings';
 import {
+  aggregateMeritIncentiveApr,
+  aggregateMerklOpportunityApr,
+  aggregateBrevisIncentiveApr,
+} from '@/lib/incentiveAggregation';
+import {
   getBrevisCampaignBreakdowns,
   getBrevisCampaignId,
   getBrevisResolvedBreakdown,
@@ -371,19 +376,6 @@ const sumNumberArray = (values?: number[], isApy = false): number => {
   }, 0);
 };
 
-const sumMeritValues = (values?: MeritIncentive[], isApy = false): number => {
-  if (!values || values.length === 0) return 0;
-  return values.reduce((sum, value) => {
-    if (!isCampaignActive(value.startDate, value.endDate)) return sum;
-    const apr = sanitizePercent(value.apr);
-    const selfApr = sanitizePercent(value.selfApr ?? 0);
-    if (isApy) {
-      return sum + (apr > 0 ? convertAprToApy(apr) : 0) + (selfApr > 0 ? convertAprToApy(selfApr) : 0);
-    }
-    return sum + apr + selfApr;
-  }, 0);
-};
-
 /**
  * Supply: `reserveSizeUsd`. Borrow: borrowed USD ≈ reserveSize × utilization (Merit TVL proxy when no campaign TVL exists).
  */
@@ -410,25 +402,6 @@ const sumForecastMeritValues = (
     const aprPercent = forecastMeritAprPercent(value, inputUsd, anchorTvlUsd);
     if (aprPercent <= 0) return sum;
     return sum + (isApy ? convertAprToApy(aprPercent) : aprPercent);
-  }, 0);
-};
-
-const sumBrevisValues = (values?: BrevisIncentive[], isApy = false): number => {
-  if (!values || values.length === 0) return 0;
-  return values.reduce((sum, value) => {
-    const breakdowns = getBrevisCampaignBreakdowns(value);
-    if (breakdowns.length === 0) return sum;
-    return (
-      sum +
-      breakdowns.reduce((breakdownSum, breakdown) => {
-        const resolved = getBrevisResolvedBreakdown(value, breakdown);
-        if (!isCampaignActive(resolved.campaignStartedAt, resolved.campaignEndedAt, Date.now(), true)) {
-          return breakdownSum;
-        }
-        const apr = sanitizePercent(resolved.campaignApr);
-        return breakdownSum + (isApy ? convertAprToApy(apr) : apr);
-      }, 0)
-    );
   }, 0);
 };
 
@@ -538,24 +511,6 @@ const sumForecastBrevisValues = (
       );
       if (aprPercent <= 0) return 0;
       return isApy ? convertAprToApy(aprPercent) : aprPercent;
-    },
-  });
-};
-
-const sumMerklValues = (
-  opportunities: MerklOpportunityGroup[] | undefined,
-  isApy: boolean,
-  tydroPointToUsdRate: number,
-  whitelistMerklCampaignIds: ReadonlySet<string> | undefined
-): number => {
-  return sumActiveCampaignBreakdownValues(opportunities, {
-    getBreakdowns: (group) => group.breakdowns,
-    getStartDate: (_group, breakdown) => breakdown.campaignStartedAt,
-    getEndDate: (_group, breakdown) => breakdown.campaignEndedAt,
-    include: (_group, breakdown) => isMerklWhitelistBreakdownIncluded(breakdown, whitelistMerklCampaignIds),
-    mapValue: (_group, breakdown) => {
-      const apr = sanitizePercent(getMerklBreakdownApr(breakdown, tydroPointToUsdRate));
-      return isApy ? convertAprToApy(apr) : apr;
     },
   });
 };
@@ -903,7 +858,7 @@ const buildIncentiveAfter = (
   return (
     sumNumberArray(protocol, isApy) +
     sumForecastMeritValues(merit, isApy, netInputUsd, getMeritAnchorTvlUsd(reserve, side)) * eligibilityRatio +
-    sumMerklValues(forecastedMerkl, isApy, tydroPointToUsdRate, whitelistMerklCampaignIds) * eligibilityRatio +
+    aggregateMerklOpportunityApr(forecastedMerkl, { isApy, tydroPointToUsdRate, whitelistMerklCampaignIds }) * eligibilityRatio +
     sumForecastBrevisValues(brevis, isApy, grossInputUsd, brevisSharedDepositsByCampaignId)
   );
 };
@@ -1253,22 +1208,22 @@ export function buildRateSimulationResult({
 
   const supplyCurrentSources = {
     protocol: sumNumberArray(reserve.supplyIncentives, isApy),
-    merit: sumMeritValues(reserve.meritSupplys, isApy),
-    merkl: sumMerklValues(reserve.merklSupplys, isApy, tydroPointToUsdRate, whitelistMerklCampaignIds),
-    brevis: sumBrevisValues(reserve.brevisSupplys, isApy),
+    merit: aggregateMeritIncentiveApr(reserve.meritSupplys, { isApy }),
+    merkl: aggregateMerklOpportunityApr(reserve.merklSupplys, { isApy, tydroPointToUsdRate, whitelistMerklCampaignIds }),
+    brevis: aggregateBrevisIncentiveApr(reserve.brevisSupplys, { isApy }),
   };
   const borrowCurrentSources = {
     protocol: sumNumberArray(reserve.borrowIncentives, isApy),
-    merit: sumMeritValues(reserve.meritBorrows, isApy),
-    merkl: sumMerklValues(reserve.merklBorrows, isApy, tydroPointToUsdRate, whitelistMerklCampaignIds),
-    brevis: sumBrevisValues(reserve.brevisBorrows, isApy),
+    merit: aggregateMeritIncentiveApr(reserve.meritBorrows, { isApy }),
+    merkl: aggregateMerklOpportunityApr(reserve.merklBorrows, { isApy, tydroPointToUsdRate, whitelistMerklCampaignIds }),
+    brevis: aggregateBrevisIncentiveApr(reserve.brevisBorrows, { isApy }),
   };
 
   const supplyAfterSources = hasAnyInput
     ? (() => {
         const meritAfterRaw =
           sumForecastMeritValues(reserve.meritSupplys, isApy, supplyMeritMerklInputUsd) * supplyMeritMerklEligibilityRatio;
-        const merklAfterRaw = sumMerklValues(
+        const merklAfterRaw = aggregateMerklOpportunityApr(
           buildForecastMerklOpportunities({
             opportunities: reserve.merklSupplys,
             inputUsd: supplyMeritMerklInputUsd,
@@ -1276,9 +1231,7 @@ export function buildRateSimulationResult({
             whitelistMerklCampaignIds,
             tydroPointToUsdRate,
           }),
-          isApy,
-          tydroPointToUsdRate,
-          whitelistMerklCampaignIds
+          { isApy, tydroPointToUsdRate, whitelistMerklCampaignIds }
         ) * supplyMeritMerklEligibilityRatio;
         const brevisAfterRaw = sumForecastBrevisValues(
           reserve.brevisSupplys,
@@ -1299,7 +1252,7 @@ export function buildRateSimulationResult({
     ? (() => {
         const meritAfterRaw =
           sumForecastMeritValues(reserve.meritBorrows, isApy, borrowMeritMerklInputUsd) * borrowMeritMerklEligibilityRatio;
-        const merklAfterRaw = sumMerklValues(
+        const merklAfterRaw = aggregateMerklOpportunityApr(
           buildForecastMerklOpportunities({
             opportunities: reserve.merklBorrows,
             inputUsd: borrowMeritMerklInputUsd,
@@ -1307,9 +1260,7 @@ export function buildRateSimulationResult({
             whitelistMerklCampaignIds,
             tydroPointToUsdRate,
           }),
-          isApy,
-          tydroPointToUsdRate,
-          whitelistMerklCampaignIds
+          { isApy, tydroPointToUsdRate, whitelistMerklCampaignIds }
         ) * borrowMeritMerklEligibilityRatio;
         const brevisAfterRaw = sumForecastBrevisValues(
           reserve.brevisBorrows,

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -54,13 +54,14 @@ export const apyToApr = (apy: number): number => {
   return aprDecimal * 100;
 };
 
-import type { BrevisIncentive, MeritIncentive, MerklOpportunityGroup, ReserveWithSpread } from '@/types/aave';
-import { isCampaignActive, sumActiveCampaignBreakdownValues } from '@/lib/campaignGroups';
-import {
-  getBrevisCampaignBreakdowns,
-  getBrevisResolvedBreakdown,
-} from '@/lib/brevis';
+import type { MeritIncentive, MerklOpportunityGroup, BrevisIncentive, ReserveWithSpread } from '@/types/aave';
+import { isCampaignActive } from '@/lib/campaignGroups';
 import { TYDRO_POINT_TO_USD_RATE, getMerklBreakdownApr } from '@/lib/tydro';
+import {
+  aggregateMeritIncentiveApr,
+  aggregateMerklOpportunityApr,
+  aggregateBrevisIncentiveApr,
+} from '@/lib/incentiveAggregation';
 
 /**
  * Opt-in key for whitelist-only Merkl breakdowns that have no usable `campaignId` (empty after trim).
@@ -99,9 +100,6 @@ export interface IncentiveCalculationOptions {
   whitelistMerklCampaignIds?: ReadonlySet<string>;
 }
 
-/**
- * Helper: Sum valid APR values from an array of numbers
- */
 const sumNumberArray = (arr?: number[]): number => {
   if (!arr || !Array.isArray(arr)) return 0;
   return arr.reduce((sum, val) => {
@@ -109,127 +107,13 @@ const sumNumberArray = (arr?: number[]): number => {
   }, 0);
 };
 
-/**
- * Helper: Sum Merit incentive APR values
- * Note: only active campaigns are counted; apr >= 0 keeps zero-APR active campaigns
- */
-const sumMeritIncentives = (meritIncentives?: MeritIncentive[]): number => {
-  if (!meritIncentives || !Array.isArray(meritIncentives)) return 0;
-  return meritIncentives.reduce((sum, incentive) => {
-    if (!isCampaignActive(incentive.startDate, incentive.endDate)) return sum;
-    const apr = incentive.apr;
-    const selfApr = incentive.selfApr || 0;
-    // Sum both apr and selfApr if they are valid (>= 0 to include active zero-APR campaigns)
-    const totalApr = (!isNaN(apr) && apr >= 0 ? apr : 0) + (!isNaN(selfApr) && selfApr >= 0 ? selfApr : 0);
-    return sum + totalApr;
+const sumNumberArrayApy = (arr?: number[]): number => {
+  if (!arr || !Array.isArray(arr)) return 0;
+  return arr.reduce((sum, val) => {
+    return (!isNaN(val) && val >= 0) ? sum + convertAprToApy(val) : sum;
   }, 0);
 };
 
-/**
- * Helper: Sum Merit incentive APY values (convert each APR to APY then sum)
- * Note: only active campaigns are counted; apr >= 0 keeps zero-APR active campaigns
- */
-const sumMeritIncentivesApy = (meritIncentives?: MeritIncentive[]): number => {
-  if (!meritIncentives || !Array.isArray(meritIncentives)) return 0;
-  return meritIncentives.reduce((sum, incentive) => {
-    if (!isCampaignActive(incentive.startDate, incentive.endDate)) return sum;
-    const apr = incentive.apr;
-    const selfApr = incentive.selfApr || 0;
-    let totalApy = 0;
-    if (!isNaN(apr) && apr >= 0) {
-      totalApy += convertAprToApy(apr);
-    }
-    if (!isNaN(selfApr) && selfApr >= 0) {
-      totalApy += convertAprToApy(selfApr);
-    }
-    return sum + totalApy;
-  }, 0);
-};
-
-/**
- * Helper: Calculate total Merkl APR from opportunity groups
- * Note: only active campaigns are counted; apr >= 0 keeps zero-APR active campaigns
- */
-const sumMerklOpportunities = (
-  opportunities?: MerklOpportunityGroup[],
-  pointToUsdRate = TYDRO_POINT_TO_USD_RATE,
-  options: IncentiveCalculationOptions = {}
-): number => {
-  return sumActiveCampaignBreakdownValues(opportunities, {
-    getBreakdowns: (group) => group.breakdowns,
-    getStartDate: (_group, breakdown) => breakdown.campaignStartedAt,
-    getEndDate: (_group, breakdown) => breakdown.campaignEndedAt,
-    include: (_group, breakdown) => isMerklWhitelistBreakdownIncluded(breakdown, options.whitelistMerklCampaignIds),
-    mapValue: (_group, breakdown) => {
-      const apr = getMerklBreakdownApr(breakdown, pointToUsdRate);
-      return !isNaN(apr) && apr >= 0 ? apr : 0;
-    },
-  });
-};
-
-/**
- * Helper: Calculate total Merkl APY from opportunity groups (convert each APR to APY then sum)
- * Note: only active campaigns are counted; apr >= 0 keeps zero-APR active campaigns
- */
-const sumMerklOpportunitiesApy = (
-  opportunities?: MerklOpportunityGroup[],
-  pointToUsdRate = TYDRO_POINT_TO_USD_RATE,
-  options: IncentiveCalculationOptions = {}
-): number => {
-  return sumActiveCampaignBreakdownValues(opportunities, {
-    getBreakdowns: (group) => group.breakdowns,
-    getStartDate: (_group, breakdown) => breakdown.campaignStartedAt,
-    getEndDate: (_group, breakdown) => breakdown.campaignEndedAt,
-    include: (_group, breakdown) => isMerklWhitelistBreakdownIncluded(breakdown, options.whitelistMerklCampaignIds),
-    mapValue: (_group, breakdown) => {
-      const apr = getMerklBreakdownApr(breakdown, pointToUsdRate);
-      return !isNaN(apr) && apr >= 0 ? convertAprToApy(apr) : 0;
-    },
-  });
-};
-
-/**
- * Helper: Sum Brevis incentives (supports array or legacy single APR)
- * Note: only active campaigns are counted; apr >= 0 keeps zero-APR active campaigns
- */
-const sumBrevisIncentives = (brevis?: BrevisIncentive[]): number => {
-  return sumActiveCampaignBreakdownValues(brevis, {
-    allowOpenEnd: true,
-    getBreakdowns: (group) => getBrevisCampaignBreakdowns(group),
-    getStartDate: (group, breakdown) => getBrevisResolvedBreakdown(group, breakdown).campaignStartedAt,
-    getEndDate: (group, breakdown) => getBrevisResolvedBreakdown(group, breakdown).campaignEndedAt,
-    mapValue: (group, breakdown) => {
-      const apr = getBrevisResolvedBreakdown(group, breakdown).campaignApr;
-      return !isNaN(apr) && apr >= 0 ? apr : 0;
-    },
-  });
-};
-
-/**
- * Helper: Sum Brevis incentives as APY (supports array or legacy single APR)
- * Note: only active campaigns are counted; apr >= 0 keeps zero-APR active campaigns
- */
-const sumBrevisIncentivesApy = (brevis?: BrevisIncentive[]): number => {
-  return sumActiveCampaignBreakdownValues(brevis, {
-    allowOpenEnd: true,
-    getBreakdowns: (group) => getBrevisCampaignBreakdowns(group),
-    getStartDate: (group, breakdown) => getBrevisResolvedBreakdown(group, breakdown).campaignStartedAt,
-    getEndDate: (group, breakdown) => getBrevisResolvedBreakdown(group, breakdown).campaignEndedAt,
-    mapValue: (group, breakdown) => {
-      const apr = getBrevisResolvedBreakdown(group, breakdown).campaignApr;
-      return !isNaN(apr) && apr >= 0 ? convertAprToApy(apr) : 0;
-    },
-  });
-};
-
-/**
- * Calculate total incentive APR from detailed sources
- * All values are in percentage form (e.g., 5 for 5%)
- * @param meritIncentives - Merit incentive objects array
- * @param merklOpportunities - Merkl opportunity groups array
- * @param brevisIncentives - Brevis incentives array
- * @param protocolIncentives - Protocol incentives array (number[])
- */
 export const calculateTotalIncentiveApr = (
   meritIncentives?: MeritIncentive[],
   merklOpportunities?: MerklOpportunityGroup[],
@@ -238,22 +122,14 @@ export const calculateTotalIncentiveApr = (
   tydroPointToUsdRate = TYDRO_POINT_TO_USD_RATE,
   options: IncentiveCalculationOptions = {}
 ): number => {
-  const meritApr = sumMeritIncentives(meritIncentives);
-  const merklApr = sumMerklOpportunities(merklOpportunities, tydroPointToUsdRate, options);
+  const meritApr = aggregateMeritIncentiveApr(meritIncentives);
+  const merklApr = aggregateMerklOpportunityApr(merklOpportunities, { tydroPointToUsdRate, whitelistMerklCampaignIds: options.whitelistMerklCampaignIds });
   const protocolApr = sumNumberArray(protocolIncentives);
-  const brevisAprValue = sumBrevisIncentives(brevisIncentives);
+  const brevisAprValue = aggregateBrevisIncentiveApr(brevisIncentives);
   
   return meritApr + merklApr + protocolApr + brevisAprValue;
 };
 
-/**
- * Calculate total incentive APY from detailed sources
- * Converts each APR source to APY and sums them (each source converted separately, then summed)
- * @param meritIncentives - Merit incentive objects array
- * @param merklOpportunities - Merkl opportunity groups array
- * @param brevisIncentives - Brevis incentives array
- * @param protocolIncentives - Protocol incentives array (number[])
- */
 export const calculateTotalIncentiveApy = (
   meritIncentives?: MeritIncentive[],
   merklOpportunities?: MerklOpportunityGroup[],
@@ -262,20 +138,10 @@ export const calculateTotalIncentiveApy = (
   tydroPointToUsdRate = TYDRO_POINT_TO_USD_RATE,
   options: IncentiveCalculationOptions = {}
 ): number => {
-  const meritApy = sumMeritIncentivesApy(meritIncentives);
-  const merklApy = sumMerklOpportunitiesApy(merklOpportunities, tydroPointToUsdRate, options);
-  
-  // Convert protocol incentives (already in APR form) to APY
-  let protocolApy = 0;
-  if (protocolIncentives && Array.isArray(protocolIncentives)) {
-    protocolIncentives.forEach(apr => {
-      if (!isNaN(apr) && apr >= 0) {
-        protocolApy += convertAprToApy(apr);
-      }
-    });
-  }
-  
-  const brevisApy = sumBrevisIncentivesApy(brevisIncentives);
+  const meritApy = aggregateMeritIncentiveApr(meritIncentives, { isApy: true });
+  const merklApy = aggregateMerklOpportunityApr(merklOpportunities, { isApy: true, tydroPointToUsdRate, whitelistMerklCampaignIds: options.whitelistMerklCampaignIds });
+  const protocolApy = sumNumberArrayApy(protocolIncentives);
+  const brevisApy = aggregateBrevisIncentiveApr(brevisIncentives, { isApy: true });
   
   return meritApy + merklApy + protocolApy + brevisApy;
 };

--- a/src/lib/incentiveAggregation.test.ts
+++ b/src/lib/incentiveAggregation.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import {
+  aggregateMeritIncentiveApr,
+  aggregateMerklOpportunityApr,
+  aggregateBrevisIncentiveApr,
+} from './incentiveAggregation';
+import type { MeritIncentive, MerklOpportunityGroup, BrevisIncentive } from '@/types/aave';
+
+function daysFromNowIso(days: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + days);
+  return d.toISOString();
+}
+
+describe('aggregateMeritIncentiveApr', () => {
+  it('sums apr + selfApr for active campaigns', () => {
+    const incentives: MeritIncentive[] = [
+      { apr: 3, selfApr: 2, link: 'https://example.com', startDate: daysFromNowIso(-1), endDate: daysFromNowIso(1) },
+    ];
+    expect(aggregateMeritIncentiveApr(incentives)).toBe(5);
+  });
+
+  it('excludes inactive campaigns', () => {
+    const incentives: MeritIncentive[] = [
+      { apr: 3, link: 'https://example.com', startDate: daysFromNowIso(-10), endDate: daysFromNowIso(-5) },
+    ];
+    expect(aggregateMeritIncentiveApr(incentives)).toBe(0);
+  });
+
+  it('returns 0 for undefined/empty', () => {
+    expect(aggregateMeritIncentiveApr()).toBe(0);
+    expect(aggregateMeritIncentiveApr([])).toBe(0);
+  });
+
+  it('sanitizes NaN/negative values', () => {
+    const incentives: MeritIncentive[] = [
+      { apr: NaN, selfApr: -1, link: 'https://example.com', startDate: daysFromNowIso(-1), endDate: daysFromNowIso(1) },
+    ];
+    expect(aggregateMeritIncentiveApr(incentives)).toBe(0);
+  });
+
+  it('converts to APY when isApy is true', () => {
+    const incentives: MeritIncentive[] = [
+      { apr: 10, link: 'https://example.com', startDate: daysFromNowIso(-1), endDate: daysFromNowIso(1) },
+    ];
+    const apr = aggregateMeritIncentiveApr(incentives);
+    const apy = aggregateMeritIncentiveApr(incentives, { isApy: true });
+    expect(apy).toBeGreaterThan(apr);
+  });
+});
+
+describe('aggregateMerklOpportunityApr', () => {
+  it('sums active campaign APRs', () => {
+    const opportunities: MerklOpportunityGroup[] = [
+      {
+        breakdowns: [
+          { campaignApr: 4, campaignId: 'a', campaignStartedAt: daysFromNowIso(-1), campaignEndedAt: daysFromNowIso(1) },
+          { campaignApr: 5, campaignId: 'b', campaignStartedAt: daysFromNowIso(-1), campaignEndedAt: daysFromNowIso(1) },
+        ],
+      },
+    ];
+    expect(aggregateMerklOpportunityApr(opportunities)).toBe(9);
+  });
+
+  it('excludes inactive campaigns', () => {
+    const opportunities: MerklOpportunityGroup[] = [
+      {
+        breakdowns: [
+          { campaignApr: 4, campaignId: 'a', campaignStartedAt: daysFromNowIso(-10), campaignEndedAt: daysFromNowIso(-5) },
+        ],
+      },
+    ];
+    expect(aggregateMerklOpportunityApr(opportunities)).toBe(0);
+  });
+
+  it('returns 0 for undefined/empty', () => {
+    expect(aggregateMerklOpportunityApr()).toBe(0);
+    expect(aggregateMerklOpportunityApr([])).toBe(0);
+  });
+
+  it('respects whitelistMerklCampaignIds', () => {
+    const opportunities: MerklOpportunityGroup[] = [
+      {
+        breakdowns: [
+          { campaignApr: 4, campaignId: 'wl-1', whitelistOnly: true, campaignStartedAt: daysFromNowIso(-1), campaignEndedAt: daysFromNowIso(1) },
+        ],
+      },
+    ];
+    expect(aggregateMerklOpportunityApr(opportunities)).toBe(0);
+    expect(aggregateMerklOpportunityApr(opportunities, { whitelistMerklCampaignIds: new Set(['wl-1']) })).toBe(4);
+  });
+});
+
+describe('aggregateBrevisIncentiveApr', () => {
+  it('sums active campaign APRs from breakdowns', () => {
+    const brevis: BrevisIncentive[] = [
+      {
+        campaignApr: 3,
+        link: 'https://example.com',
+        campaignStartedAt: daysFromNowIso(-1),
+        campaignEndedAt: daysFromNowIso(1),
+        message: 'Active',
+      },
+    ];
+    expect(aggregateBrevisIncentiveApr(brevis)).toBe(3);
+  });
+
+  it('excludes inactive campaigns', () => {
+    const brevis: BrevisIncentive[] = [
+      {
+        campaignApr: 3,
+        link: 'https://example.com',
+        campaignStartedAt: daysFromNowIso(-10),
+        campaignEndedAt: daysFromNowIso(-5),
+        message: 'Past',
+      },
+    ];
+    expect(aggregateBrevisIncentiveApr(brevis)).toBe(0);
+  });
+
+  it('returns 0 for undefined/empty', () => {
+    expect(aggregateBrevisIncentiveApr()).toBe(0);
+    expect(aggregateBrevisIncentiveApr([])).toBe(0);
+  });
+
+  it('converts to APY when isApy is true', () => {
+    const brevis: BrevisIncentive[] = [
+      {
+        campaignApr: 10,
+        link: 'https://example.com',
+        campaignStartedAt: daysFromNowIso(-1),
+        campaignEndedAt: daysFromNowIso(1),
+        message: 'Active',
+      },
+    ];
+    const apr = aggregateBrevisIncentiveApr(brevis);
+    const apy = aggregateBrevisIncentiveApr(brevis, { isApy: true });
+    expect(apy).toBeGreaterThan(apr);
+  });
+});

--- a/src/lib/incentiveAggregation.ts
+++ b/src/lib/incentiveAggregation.ts
@@ -1,0 +1,75 @@
+import type { BrevisIncentive, MeritIncentive, MerklOpportunityGroup } from '@/types/aave';
+import { isCampaignActive, sumActiveCampaignBreakdownValues } from '@/lib/campaignGroups';
+import {
+  getBrevisCampaignBreakdowns,
+  getBrevisResolvedBreakdown,
+} from '@/lib/brevis';
+import { TYDRO_POINT_TO_USD_RATE, getMerklBreakdownApr } from '@/lib/tydro';
+import { convertAprToApy } from '@/lib/formatters';
+import { isMerklWhitelistBreakdownIncluded } from '@/lib/formatters';
+
+const sanitizePercent = (value: number): number =>
+  Number.isFinite(value) && value >= 0 ? value : 0;
+
+export interface IncentiveAggregationOptions {
+  isApy?: boolean;
+  /** Merkl campaign IDs the user opted into for whitelist-only APR */
+  whitelistMerklCampaignIds?: ReadonlySet<string>;
+  /** Point-to-USD conversion rate for Merkl points campaigns */
+  tydroPointToUsdRate?: number;
+}
+
+export function aggregateMeritIncentiveApr(
+  meritIncentives?: MeritIncentive[],
+  options: IncentiveAggregationOptions = {},
+): number {
+  if (!meritIncentives?.length) return 0;
+  const { isApy = false } = options;
+  return meritIncentives.reduce((sum, incentive) => {
+    if (!isCampaignActive(incentive.startDate, incentive.endDate)) return sum;
+    const apr = sanitizePercent(incentive.apr);
+    const selfApr = sanitizePercent(incentive.selfApr ?? 0);
+    if (isApy) {
+      return sum + (apr > 0 ? convertAprToApy(apr) : 0) + (selfApr > 0 ? convertAprToApy(selfApr) : 0);
+    }
+    return sum + apr + selfApr;
+  }, 0);
+}
+
+export function aggregateMerklOpportunityApr(
+  opportunities?: MerklOpportunityGroup[],
+  options: IncentiveAggregationOptions = {},
+): number {
+  const {
+    isApy = false,
+    whitelistMerklCampaignIds,
+    tydroPointToUsdRate = TYDRO_POINT_TO_USD_RATE,
+  } = options;
+  return sumActiveCampaignBreakdownValues(opportunities, {
+    getBreakdowns: (group) => group.breakdowns,
+    getStartDate: (_group, breakdown) => breakdown.campaignStartedAt,
+    getEndDate: (_group, breakdown) => breakdown.campaignEndedAt,
+    include: (_group, breakdown) => isMerklWhitelistBreakdownIncluded(breakdown, whitelistMerklCampaignIds),
+    mapValue: (_group, breakdown) => {
+      const apr = sanitizePercent(getMerklBreakdownApr(breakdown, tydroPointToUsdRate));
+      return isApy ? convertAprToApy(apr) : apr;
+    },
+  });
+}
+
+export function aggregateBrevisIncentiveApr(
+  brevis?: BrevisIncentive[],
+  options: IncentiveAggregationOptions = {},
+): number {
+  const { isApy = false } = options;
+  return sumActiveCampaignBreakdownValues(brevis, {
+    allowOpenEnd: true,
+    getBreakdowns: (group) => getBrevisCampaignBreakdowns(group),
+    getStartDate: (group, breakdown) => getBrevisResolvedBreakdown(group, breakdown).campaignStartedAt,
+    getEndDate: (group, breakdown) => getBrevisResolvedBreakdown(group, breakdown).campaignEndedAt,
+    mapValue: (group, breakdown) => {
+      const apr = sanitizePercent(getBrevisResolvedBreakdown(group, breakdown).campaignApr);
+      return isApy ? convertAprToApy(apr) : apr;
+    },
+  });
+}


### PR DESCRIPTION
Change npm `open-pull-requests-limit` from 0 to 5 so Dependabot can open security fix PRs. Add `automerge` + `dependencies` labels to both npm and github-actions so PRs auto-merge on green CI.