### PR TITLE
fix(ci): skip enable-automerge when checks have failures

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -47,6 +47,7 @@ jobs:
 
       - name: Wait for CI checks to stabilise
         if: steps.pr.outputs.skip != 'true'
+        id: wait-checks
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -56,14 +57,15 @@ jobs:
             const repo = context.repo.repo;
             const maxPolls = 20;
             const pollIntervalMs = 15000;
+            const ref = context.payload.pull_request
+              ? context.payload.pull_request.head.ref
+              : context.payload.check_suite.head_branch;
 
             for (let i = 0; i < maxPolls; i++) {
               const { data: checks } = await github.rest.checks.listForRef({
                 owner,
                 repo,
-                ref: context.payload.pull_request
-                  ? context.payload.pull_request.head.ref
-                  : context.payload.check_suite.head_branch,
+                ref,
                 per_page: 100
               });
 
@@ -74,7 +76,20 @@ jobs:
               const pending = total - completed;
 
               if (pending <= 0 || total === 0) {
-                core.info(`All ${total} check runs completed after ${(i + 1)} poll(s).`);
+                const failed = checks.check_runs.filter(
+                  (r) => r.status === 'completed' && r.conclusion !== 'success' && r.conclusion !== 'skipped'
+                ).length;
+
+                if (failed > 0) {
+                  core.notice(
+                    `All checks completed but ${failed} failed. Skipping auto-merge enable — will retry on next successful check run.`
+                  );
+                  core.setOutput('has_failures', 'true');
+                  return;
+                }
+
+                core.info(`All ${total} check runs passed after ${(i + 1)} poll(s).`);
+                core.setOutput('has_failures', 'false');
                 return;
               }
 
@@ -85,9 +100,10 @@ jobs:
             }
 
             core.warning(`Timed out after ${maxPolls} polls, proceeding anyway.`);
+            core.setOutput('has_failures', 'unknown');
 
       - name: Enable auto-merge when checks pass
-        if: steps.pr.outputs.skip != 'true'
+        if: steps.pr.outputs.skip != 'true' && steps.wait-checks.outputs.has_failures != 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -144,24 +160,16 @@ jobs:
                 }
               }
             `;
-            const maxAttempts = 5;
-            const baseDelayMs = 30000;
-            for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-              try {
-                await github.graphql(enableAutoMergeMutation, { pullRequestId: prInfo.id });
-                core.info(`Enabled auto-merge for PR #${prNumber} on attempt ${attempt}/${maxAttempts}`);
-                return;
-              } catch (error) {
-                const message = String(error && error.message ? error.message : error);
-                const isUnstable = message.toLowerCase().includes('unstable status');
-                const isLastAttempt = attempt === maxAttempts;
-                if (!isUnstable || isLastAttempt) {
-                  throw error;
-                }
-                const waitMs = baseDelayMs * attempt;
-                core.warning(
-                  `PR #${prNumber} is in unstable status (attempt ${attempt}/${maxAttempts}). Retrying in ${waitMs / 1000}s.`
+            try {
+              await github.graphql(enableAutoMergeMutation, { pullRequestId: prInfo.id });
+              core.info(`Enabled auto-merge for PR #${prNumber}`);
+            } catch (error) {
+              const message = String(error && error.message ? error.message : error);
+              if (message.toLowerCase().includes('unstable status')) {
+                core.notice(
+                  `PR #${prNumber} is still unstable — likely a transient race. A future check_suite completed event will retry.`
                 );
-                await new Promise((resolve) => setTimeout(resolve, waitMs));
+                return;
               }
+              throw error;
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -119,11 +119,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -132,7 +134,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -140,19 +144,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -169,12 +175,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -184,12 +192,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -199,7 +209,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -207,25 +219,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -235,7 +251,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -243,7 +261,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -251,7 +271,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -259,23 +281,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.6",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -285,29 +311,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -315,12 +345,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -861,9 +893,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -942,9 +974,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4519,9 +4551,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5271,9 +5303,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5804,6 +5836,8 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -5832,6 +5866,8 @@
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -6685,6 +6721,8 @@
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -7647,6 +7685,8 @@
     },
     "node_modules/semver": {
       "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -8410,6 +8450,8 @@
     },
     "node_modules/yallist": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
     },

--- a/src/components/dashboard/IncentiveTooltip.tsx
+++ b/src/components/dashboard/IncentiveTooltip.tsx
@@ -2,7 +2,7 @@ import { useRef, useEffect, useLayoutEffect, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { ExternalLink, X } from 'lucide-react';
 import { useTheme } from 'next-themes';
-import { ReserveWithSpread, MeritIncentive, MerklOpportunityGroup, BrevisIncentive } from '@/types/aave';
+import { ReserveWithSpread, MeritCampaignGroup, MerklOpportunityGroup, BrevisIncentive } from '@/types/aave';
 import {
   formatPercent,
   convertAprToApy,
@@ -311,57 +311,59 @@ const IncentiveTooltip = ({
       }
     }
 
-    // Merit incentives (MeritIncentive array)
-    const meritIncentives: MeritIncentive[] | undefined = type === 'supply' ? reserve.meritSupplys : reserve.meritBorrows;
-    if (meritIncentives && Array.isArray(meritIncentives)) {
-      meritIncentives.forEach((merit, index) => {
-        if (!isCampaignActive(merit.startDate, merit.endDate)) return;
-        const apr = merit.apr;
-        const selfApr = merit.selfApr || 0;
-        
-        const baseAprPercent = !isNaN(apr) && apr >= 0 ? apr : 0;
-        const selfAprPercent = !isNaN(selfApr) && selfApr >= 0 ? selfApr : 0;
-        const totalForecastAprPercent = baseAprPercent + selfAprPercent;
+    // Merit incentives (MeritCampaignGroup array)
+    const meritGroups: MeritCampaignGroup[] | undefined = type === 'supply' ? reserve.meritSupplys : reserve.meritBorrows;
+    if (meritGroups && Array.isArray(meritGroups)) {
+      meritGroups.forEach((group, index) => {
+        const activeBreakdowns = (group.breakdowns ?? []).filter(
+          (bd) => isCampaignActive(bd.campaignStartedAt, bd.campaignEndedAt)
+        );
+        if (!activeBreakdowns.length) return;
 
-        // Convert each APR to APY separately then sum (convertAprToApy is non-linear)
+        const totalAprPercent = activeBreakdowns.reduce((s, bd) => {
+          const apr = !isNaN(bd.campaignApr) && bd.campaignApr >= 0 ? bd.campaignApr : 0;
+          return s + apr;
+        }, 0);
+
         let totalValue = 0;
         if (isApy) {
-          if (baseAprPercent > 0) totalValue += convertAprToApy(baseAprPercent);
-          if (selfAprPercent > 0) totalValue += convertAprToApy(selfAprPercent);
+          activeBreakdowns.forEach((bd) => {
+            const apr = !isNaN(bd.campaignApr) && bd.campaignApr >= 0 ? bd.campaignApr : 0;
+            if (apr > 0) totalValue += convertAprToApy(apr);
+          });
         } else {
-          totalValue = totalForecastAprPercent;
+          totalValue = totalAprPercent;
         }
-        
+
         if (totalValue >= 0) {
-          const name = merit.name
-            ? merit.name
-            : meritIncentives.length > 1 
+          const name = group.name
+            ? group.name
+            : meritGroups.length > 1 
               ? `ACI Incentive ${index + 1}`
               : 'ACI Incentive';
 
-          const { baseMessage, selfMessage } = splitMeritMessageBySelfAuth(merit.message);
+          const firstBd = activeBreakdowns[0];
+          const startDate = firstBd?.campaignStartedAt ?? '';
+          const endDate = firstBd?.campaignEndedAt ?? '';
+          const { baseMessage, selfMessage } = splitMeritMessageBySelfAuth(group.message);
 
           const meritCampaigns: NonNullable<IncentiveSource['campaigns']> = [];
-          if (baseAprPercent > 0) {
+          activeBreakdowns.forEach((bd) => {
+            const apr = !isNaN(bd.campaignApr) && bd.campaignApr >= 0 ? bd.campaignApr : 0;
+            if (apr <= 0) return;
+            const bdMessage = bd.message;
+            const msgText = typeof bdMessage === 'string' ? bdMessage.toLowerCase() : JSON.stringify(bdMessage ?? '').toLowerCase();
+            const isSelf = msgText.includes('self authentication');
+            const { baseMessage: bdBaseMsg, selfMessage: bdSelfMsg } = splitMeritMessageBySelfAuth(bdMessage);
             meritCampaigns.push({
-              value: isApy ? convertAprToApy(baseAprPercent) : baseAprPercent,
-              dateRange: formatDateRange(merit.startDate, merit.endDate) || undefined,
-              startDate: merit.startDate,
-              endDate: merit.endDate,
-              message: baseMessage ?? merit.message,
+              value: isApy ? convertAprToApy(apr) : apr,
+              dateRange: formatDateRange(bd.campaignStartedAt, bd.campaignEndedAt) || undefined,
+              startDate: bd.campaignStartedAt,
+              endDate: bd.campaignEndedAt,
+              message: isSelf ? (bdSelfMsg ?? selfMessage) : (bdBaseMsg ?? baseMessage ?? bdMessage),
               sourceType: 'ACI',
             });
-          }
-          if (selfAprPercent > 0) {
-            meritCampaigns.push({
-              value: isApy ? convertAprToApy(selfAprPercent) : selfAprPercent,
-              dateRange: formatDateRange(merit.startDate, merit.endDate) || undefined,
-              startDate: merit.startDate,
-              endDate: merit.endDate,
-              message: selfMessage,
-              sourceType: 'ACI',
-            });
-          }
+          });
 
           sources.push({
             name,
@@ -369,17 +371,17 @@ const IncentiveTooltip = ({
             color: 'text-foreground',
             bgColor: 'bg-muted/60',
             sourceType: 'ACI',
-            link: merit.link,
-            message: merit.message,
-            dateRange: formatDateRange(merit.startDate, merit.endDate) || undefined,
+            link: group.link,
+            message: group.message,
+            dateRange: formatDateRange(startDate, endDate) || undefined,
             campaigns: meritCampaigns.length > 0
               ? meritCampaigns
               : [{
                   value: totalValue,
-                  dateRange: formatDateRange(merit.startDate, merit.endDate) || undefined,
-                  startDate: merit.startDate,
-                  endDate: merit.endDate,
-                  message: merit.message,
+                  dateRange: formatDateRange(startDate, endDate) || undefined,
+                  startDate,
+                  endDate,
+                  message: group.message,
                 }],
           });
         }

--- a/src/components/dashboard/SimulationSubRow.tsx
+++ b/src/components/dashboard/SimulationSubRow.tsx
@@ -24,19 +24,21 @@ import {
   type IncentiveSourceRow,
   type SimulationTableRow,
 } from '@/lib/simulationIncentiveTableRows';
-import type { ReserveWithSpread, MeritIncentive, MerklOpportunityGroup, BrevisIncentive } from '@/types/aave';
+import type { ReserveWithSpread, MeritCampaignGroup, MerklOpportunityGroup, BrevisIncentive } from '@/types/aave';
 import { ETHEREUM_MARKET_NAMES } from '@/types/aave';
 import { getFirstActiveBrevisLink } from '@/lib/brevis';
 
-const getFirstMeritLink = (merits?: MeritIncentive[]): string | null => {
+const getFirstMeritLink = (merits?: MeritCampaignGroup[]): string | null => {
   if (!merits || !Array.isArray(merits)) return null;
   const now = Date.now();
-  for (const merit of merits) {
-    const start = Date.parse(merit.startDate);
-    const end = Date.parse(merit.endDate);
-    if (!Number.isNaN(start) && !Number.isNaN(end) && now >= start && now <= end && merit.link) {
-      return merit.link;
-    }
+  for (const group of merits) {
+    if (!group.link) continue;
+    const hasActive = (group.breakdowns ?? []).some((bd) => {
+      const start = Date.parse(bd.campaignStartedAt);
+      const end = Date.parse(bd.campaignEndedAt);
+      return !Number.isNaN(start) && !Number.isNaN(end) && now >= start && now <= end;
+    });
+    if (hasActive) return group.link;
   }
   return null;
 };

--- a/src/hooks/useRateSimulation.test.ts
+++ b/src/hooks/useRateSimulation.test.ts
@@ -4,6 +4,7 @@ import type {
   MerklForecastWireItem,
   MerklCampaignBreakdown,
   ReserveWithSpread,
+  IncentiveMessage,
 } from '@/types/aave';
 import type { RateCalcInput } from '@/lib/interestRateCalculator';
 import { buildForecastMerklOpportunities, buildRateSimulationResult } from '@/hooks/useRateSimulation';
@@ -565,24 +566,24 @@ describe('buildRateSimulationResult', () => {
       ...baseReserve,
       meritSupplys: [
         {
-          apr: 4.084439890516138,
-          selfApr: 4.084439890516138,
           link: 'https://apps.aavechan.com/merit/celo-supply-usdt',
-          startDate: '2020-01-01',
-          endDate: '2099-01-01',
           name: 'Supply USDT',
           message: [
             {
               action: 'Supply USDT',
               description:
-                'Rewards are distributed using the following formula: f(USD₮ aToken Holding - USD₮ vToken Holding / USD₮ Liquidation Threshold)',
+                'Rewards are distributed using the following formula: f(USDb. aToken Holding - USDb. vToken Holding / USDb. Liquidation Threshold)',
             },
             {
               action: 'Self Authentication',
               description:
                 'Supply USDT and double your yield by verifying your humanity through Self for the first $1000 USDT supplied per user.',
             },
-          ] as unknown as string,
+          ] as unknown as IncentiveMessage,
+          breakdowns: [
+            { campaignApr: 4.084439890516138, campaignId: 'base', campaignStartedAt: '2020-01-01', campaignEndedAt: '2099-01-01' },
+            { campaignApr: 4.084439890516138, campaignId: 'self', campaignStartedAt: '2020-01-01', campaignEndedAt: '2099-01-01', positionCap: 1000, message: 'Self Authentication' },
+          ],
         },
       ],
     };

--- a/src/hooks/useRateSimulation.ts
+++ b/src/hooks/useRateSimulation.ts
@@ -62,12 +62,13 @@ import {
 } from '@/lib/tydro';
 import type {
   BrevisIncentive,
-  MeritIncentive,
+  MeritCampaignGroup,
   MerklCampaignBreakdown,
   MerklForecastWireItem,
   MerklOpportunityGroup,
   ReserveWithSpread,
   TokenPricesIndex,
+  IncentiveMessage,
 } from '@/types/aave';
 
 const FORECAST_TOKEN_PRICE_QUERY_KEY = ['forecast-token-price'] as const;
@@ -391,15 +392,18 @@ const getMeritAnchorTvlUsd = (reserve: ReserveWithSpread, side: RateSide): numbe
 };
 
 const sumForecastMeritValues = (
-  values: MeritIncentive[] | undefined,
+  values: MeritCampaignGroup[] | undefined,
   isApy: boolean,
   inputUsd: number,
   anchorTvlUsd?: number,
 ): number => {
   if (!values || values.length === 0) return 0;
-  return values.reduce((sum, value) => {
-    if (!isCampaignActive(value.startDate, value.endDate)) return sum;
-    const aprPercent = forecastMeritAprPercent(value, inputUsd, anchorTvlUsd);
+  return values.reduce((sum, group) => {
+    const activeBreakdowns = (group.breakdowns ?? []).filter(
+      (bd) => isCampaignActive(bd.campaignStartedAt, bd.campaignEndedAt)
+    );
+    if (!activeBreakdowns.length) return sum;
+    const aprPercent = forecastMeritAprPercent(group, inputUsd, anchorTvlUsd);
     if (aprPercent <= 0) return sum;
     return sum + (isApy ? convertAprToApy(aprPercent) : aprPercent);
   }, 0);
@@ -549,11 +553,11 @@ const finalizeCampaignDetailRows = (
   return shouldExposeCampaignRows(rows) ? rows : [];
 };
 
-const extractActionLabelFromMeritMessage = (message: MeritIncentive['message']): string | null => {
+const extractActionLabelFromMeritMessage = (message?: IncentiveMessage): string | null => {
   if (!message) return null;
   if (Array.isArray(message)) {
     for (const item of message) {
-      const label = extractActionLabelFromMeritMessage(item as MeritIncentive['message']);
+      const label = extractActionLabelFromMeritMessage(item as IncentiveMessage);
       if (label) return label;
     }
     return null;
@@ -562,7 +566,7 @@ const extractActionLabelFromMeritMessage = (message: MeritIncentive['message']):
     const actionValue = (message as Record<string, unknown>).action;
     if (typeof actionValue === 'string' && actionValue.trim()) return actionValue.trim();
     for (const value of Object.values(message)) {
-      const label = extractActionLabelFromMeritMessage(value as MeritIncentive['message']);
+      const label = extractActionLabelFromMeritMessage(value as IncentiveMessage);
       if (label) return label;
     }
     return null;
@@ -571,7 +575,7 @@ const extractActionLabelFromMeritMessage = (message: MeritIncentive['message']):
 };
 
 const buildMeritCampaignDetails = (
-  merits: MeritIncentive[] | undefined,
+  meritGroups: MeritCampaignGroup[] | undefined,
   isApy: boolean,
   inputUsd: number,
   hasAnyInput: boolean,
@@ -579,8 +583,8 @@ const buildMeritCampaignDetails = (
   eligibilityRatio = 1,
   grossInputUsd?: number,
 ): SimulationCampaignDetail[] => {
-  const rows: SimulationCampaignDetail[] = [];
-  if (!merits?.length) return rows;
+  const rows: LabeledCampaignRow[] = [];
+  if (!meritGroups?.length) return [];
 
   const netNote = grossInputUsd !== undefined ? buildNetEligibilityNote(inputUsd, grossInputUsd) : null;
   const appendNetNote = (note: string | undefined): string | undefined => {
@@ -588,20 +592,36 @@ const buildMeritCampaignDetails = (
     return note ? `${note} · ${netNote}` : netNote;
   };
 
-  const activeMerits = merits.filter((m) => isCampaignActive(m.startDate, m.endDate));
+  let globalIndex = 0;
 
-  activeMerits.forEach((merit, meritIndex) => {
-    const { baseMessage, selfMessage } = splitMeritMessageBySelfAuth(merit.message);
-    const selfCapUsd = extractMeritSelfCapUsd(selfMessage);
-    const baseAprPercent = sanitizePercent(merit.apr);
-    const selfAprPercent = sanitizePercent(merit.selfApr ?? 0);
-    const meritName = (merit.name?.trim() || 'Merit');
-    const hasBaseLeg = baseAprPercent > 0;
-    const baseLabel = extractActionLabelFromMeritMessage(baseMessage) ?? meritName;
-    const selfLabel = extractActionLabelFromMeritMessage(selfMessage) ?? (hasBaseLeg ? `${baseLabel} #2` : meritName);
-    const meritHref = typeof merit.link === 'string' && merit.link.trim() ? merit.link.trim() : null;
+  meritGroups.forEach((group) => {
+    const activeBreakdowns = (group.breakdowns ?? []).filter(
+      (bd) => isCampaignActive(bd.campaignStartedAt, bd.campaignEndedAt)
+    );
+    if (!activeBreakdowns.length) return;
 
-    if (baseAprPercent > 0) {
+    const groupMessage = group.message;
+    const { baseMessage, selfMessage } = splitMeritMessageBySelfAuth(groupMessage);
+    const meritName = (group.name?.trim() || 'Merit');
+    const meritHref = typeof group.link === 'string' && group.link.trim() ? group.link.trim() : null;
+
+    const selfBd = activeBreakdowns.find((bd) => {
+      const msg = bd.message;
+      const text = typeof msg === 'string' ? msg.toLowerCase() : JSON.stringify(msg ?? '').toLowerCase();
+      return text.includes('self authentication');
+    });
+    const baseBreakdowns = activeBreakdowns.filter((bd) => bd !== selfBd);
+
+    baseBreakdowns.forEach((bd) => {
+      const bdSelfMessage = bd.message
+        ? splitMeritMessageBySelfAuth(bd.message).selfMessage
+        : undefined;
+      const bdBaseMessage = bd.message
+        ? splitMeritMessageBySelfAuth(bd.message).baseMessage
+        : undefined;
+      const baseAprPercent = sanitizePercent(bd.campaignApr);
+      if (baseAprPercent <= 0) return;
+      const label = extractActionLabelFromMeritMessage(bdBaseMessage ?? baseMessage) ?? meritName;
       const baseCurrent = meritAprToDisplay(baseAprPercent, isApy);
       let baseAfter: number | null = null;
       if (inputUsd > 0) {
@@ -609,9 +629,8 @@ const buildMeritCampaignDetails = (
           mode: 'MERIT_BASE',
           depositUsd: inputUsd,
           forecastAprPercent: baseAprPercent,
-          startDate: merit.startDate,
-          endDate: merit.endDate,
-          lastRoundRewardUsd: merit.lastRoundRewardUsd,
+          startDate: bd.campaignStartedAt,
+          endDate: bd.campaignEndedAt,
           anchorTvlUsd: meritAnchorTvlUsd,
         });
         if (fp) {
@@ -622,8 +641,8 @@ const buildMeritCampaignDetails = (
       }
       const delta = baseAfter !== null ? baseAfter - baseCurrent : null;
       rows.push({
-        id: `merit-${meritIndex}-base`,
-        label: baseLabel,
+        id: `merit-${globalIndex}-base`,
+        baseLabel: label,
         current: baseCurrent,
         after: baseAfter,
         delta,
@@ -631,56 +650,63 @@ const buildMeritCampaignDetails = (
         capWarning: false,
         href: meritHref,
       });
-    }
+      globalIndex++;
+    });
 
-    if (selfAprPercent > 0) {
-      const selfCurrent = meritAprToDisplay(selfAprPercent, isApy);
-      let selfAfter: number | null = null;
-      let capNote: string | undefined;
-      let capWarning = false;
-      if (inputUsd > 0) {
-        const fp = forecastMeritCampaign({
-          mode: 'MERIT_SELF_CAP',
-          depositUsd: inputUsd,
-          forecastAprPercent: selfAprPercent,
-          selfCapUsd: selfCapUsd ?? undefined,
-          startDate: merit.startDate,
-          endDate: merit.endDate,
-          baseAprPercent: baseAprPercent > 0 ? baseAprPercent : undefined,
-          baseLastRoundRewardUsd: merit.lastRoundRewardUsd,
-          anchorTvlUsd: meritAnchorTvlUsd,
-        });
-        if (fp) {
-          selfAfter = meritForecastAprToDisplay(fp.apr, isApy) * eligibilityRatio;
-          if (typeof fp.selfCapUsd === 'number' && typeof fp.selfEligibleUsd === 'number') {
-            const ceiling = buildMeritSelfDepositCeilingEffect({
-              inputUsd,
-              selfEligibleUsd: fp.selfEligibleUsd,
-              depositCeilingUsd: fp.selfCapUsd,
-            });
-            ({ capNote, capWarning } = ceilingEffectToSimulationFields(ceiling));
+    if (selfBd) {
+      const selfAprPercent = sanitizePercent(selfBd.campaignApr);
+      if (selfAprPercent > 0) {
+        const selfCapUsd = extractMeritSelfCapUsd(selfBd.message ?? selfMessage, selfBd.positionCap);
+        const selfCurrent = meritAprToDisplay(selfAprPercent, isApy);
+        let selfAfter: number | null = null;
+        let capNote: string | undefined;
+        let capWarning = false;
+        const baseAprPercent = baseBreakdowns.reduce((s, b) => s + sanitizePercent(b.campaignApr), 0);
+        if (inputUsd > 0) {
+          const fp = forecastMeritCampaign({
+            mode: 'MERIT_SELF_CAP',
+            depositUsd: inputUsd,
+            forecastAprPercent: selfAprPercent,
+            selfCapUsd: selfCapUsd ?? undefined,
+            startDate: selfBd.campaignStartedAt,
+            endDate: selfBd.campaignEndedAt,
+            baseAprPercent: baseAprPercent > 0 ? baseAprPercent : undefined,
+            anchorTvlUsd: meritAnchorTvlUsd,
+          });
+          if (fp) {
+            selfAfter = meritForecastAprToDisplay(fp.apr, isApy) * eligibilityRatio;
+            if (typeof fp.selfCapUsd === 'number' && typeof fp.selfEligibleUsd === 'number') {
+              const ceiling = buildMeritSelfDepositCeilingEffect({
+                inputUsd,
+                selfEligibleUsd: fp.selfEligibleUsd,
+                depositCeilingUsd: fp.selfCapUsd,
+              });
+              ({ capNote, capWarning } = ceilingEffectToSimulationFields(ceiling));
+            }
+          } else {
+            selfAfter = selfCurrent;
           }
-        } else {
-          selfAfter = selfCurrent;
+        } else if (hasAnyInput) {
+          selfAfter = 0;
         }
-      } else if (hasAnyInput) {
-        selfAfter = 0;
+        const delta = selfAfter !== null ? selfAfter - selfCurrent : null;
+        const selfLabel = extractActionLabelFromMeritMessage(selfBd.message ?? selfMessage) ?? (baseBreakdowns.length > 0 ? `${meritName} #2` : meritName);
+        rows.push({
+          id: `merit-${globalIndex}-self`,
+          baseLabel: selfLabel,
+          current: selfCurrent,
+          after: selfAfter,
+          delta,
+          capNote: appendNetNote(capNote),
+          capWarning,
+          href: meritHref,
+        });
+        globalIndex++;
       }
-      const delta = selfAfter !== null ? selfAfter - selfCurrent : null;
-      rows.push({
-        id: `merit-${meritIndex}-self`,
-        label: selfLabel,
-        current: selfCurrent,
-        after: selfAfter,
-        delta,
-        capNote: appendNetNote(capNote),
-        capWarning,
-        href: meritHref,
-      });
     }
   });
 
-  return shouldExposeCampaignRows(rows) ? rows : [];
+  return finalizeCampaignDetailRows(rows);
 };
 
 const buildMerklCampaignDetails = (

--- a/src/lib/apiSchemas.test.ts
+++ b/src/lib/apiSchemas.test.ts
@@ -18,11 +18,17 @@ const buildMarketsPayload = (message: unknown) => ({
       vTokenAddress: '0xb1234',
       meritSupplys: [
         {
-          apr: 4.16,
           link: 'https://app.merit.systems/campaign',
+          name: 'Supply USDT',
           message,
-          startDate: '2026-02-26',
-          endDate: '2026-03-12',
+          breakdowns: [
+            {
+              campaignApr: 4.16,
+              campaignId: 'base',
+              campaignStartedAt: '2026-02-26',
+              campaignEndedAt: '2026-03-12',
+            },
+          ],
         },
       ],
     },

--- a/src/lib/apiSchemas.ts
+++ b/src/lib/apiSchemas.ts
@@ -10,17 +10,27 @@ const IncentiveMessageSchema: z.ZodType<IncentiveMessage> = z.lazy(() =>
   ])
 );
 
-// ── Merit incentive ──
-const MeritIncentiveSchema = z.object({
-  apr: z.number(),
-  selfApr: z.number().optional(),
-  link: z.string(),
+// ── Merit campaign breakdown ──
+const MeritCampaignBreakdownSchema = z.object({
+  campaignApr: z.number(),
+  campaignStartedAt: z.string(),
+  campaignEndedAt: z.string(),
+  campaignId: z.string(),
+  campaignType: z.string().optional(),
+  positionCap: z.number().optional(),
+  message: IncentiveMessageSchema.optional(),
+  aprCap: z.number().nullable().optional(),
+  rewardTokenSymbol: z.string().optional(),
+  totalBudget: z.number().optional(),
+  latestTvl: z.number().optional(),
+}).passthrough();
+
+const MeritCampaignGroupSchema = z.object({
+  link: z.string().optional(),
   name: z.string().optional(),
   message: IncentiveMessageSchema.optional(),
-  startDate: z.string(),
-  endDate: z.string(),
-  lastRoundRewardUsd: z.number().optional(),
-});
+  breakdowns: z.array(MeritCampaignBreakdownSchema),
+}).passthrough();
 
 // ── Merkl campaign breakdown ──
 const MerklCampaignBreakdownSchema = z.object({
@@ -137,8 +147,8 @@ const ReserveWithSpreadSchema = z.object({
   borrowApy: z.number().optional(),
   supplyIncentives: z.array(z.number()).optional(),
   borrowIncentives: z.array(z.number()).optional(),
-  meritSupplys: z.array(MeritIncentiveSchema).optional(),
-  meritBorrows: z.array(MeritIncentiveSchema).optional(),
+  meritSupplys: z.array(MeritCampaignGroupSchema).optional(),
+  meritBorrows: z.array(MeritCampaignGroupSchema).optional(),
   merklSupplys: z.array(MerklOpportunityGroupSchema).optional(),
   merklBorrows: z.array(MerklOpportunityGroupSchema).optional(),
   merklHolds: z.array(MerklOpportunityGroupSchema).optional(),

--- a/src/lib/formatters.test.ts
+++ b/src/lib/formatters.test.ts
@@ -8,7 +8,7 @@ import {
   MERKL_WHITELIST_NO_CAMPAIGN_ID_SENTINEL,
   resolveVisibleIncentiveBadgeValue,
 } from './formatters';
-import type { BrevisIncentive, MeritIncentive, MerklOpportunityGroup, ReserveWithSpread } from '@/types/aave';
+import type { BrevisIncentive, MeritCampaignGroup, MerklOpportunityGroup, ReserveWithSpread } from '@/types/aave';
 
 const daysFromNowIso = (days: number): string => {
   const date = new Date(Date.now() + days * 24 * 60 * 60 * 1000);
@@ -17,25 +17,25 @@ const daysFromNowIso = (days: number): string => {
 
 describe('incentive calculations only include active campaigns', () => {
   it('counts only active merit/merkl/brevis campaigns for APR totals', () => {
-    const meritIncentives: MeritIncentive[] = [
+    const meritIncentives: MeritCampaignGroup[] = [
       {
-        apr: 2,
-        selfApr: 1,
         link: 'https://example.com/active-merit',
-        startDate: daysFromNowIso(-1),
-        endDate: daysFromNowIso(1),
+        breakdowns: [
+          { campaignApr: 2, campaignId: 'base', campaignStartedAt: daysFromNowIso(-1), campaignEndedAt: daysFromNowIso(1) },
+          { campaignApr: 1, campaignId: 'self', campaignStartedAt: daysFromNowIso(-1), campaignEndedAt: daysFromNowIso(1) },
+        ],
       },
       {
-        apr: 10,
         link: 'https://example.com/past-merit',
-        startDate: daysFromNowIso(-10),
-        endDate: daysFromNowIso(-5),
+        breakdowns: [
+          { campaignApr: 10, campaignId: 'past', campaignStartedAt: daysFromNowIso(-10), campaignEndedAt: daysFromNowIso(-5) },
+        ],
       },
       {
-        apr: 5,
         link: 'https://example.com/missing-merit-dates',
-        startDate: '',
-        endDate: '',
+        breakdowns: [
+          { campaignApr: 5, campaignId: 'no-dates', campaignStartedAt: '', campaignEndedAt: '' },
+        ],
       },
     ];
 
@@ -99,19 +99,19 @@ describe('incentive calculations only include active campaigns', () => {
   });
 
   it('uses the same active-only scope for APY totals', () => {
-    const meritIncentives: MeritIncentive[] = [
+    const meritIncentives: MeritCampaignGroup[] = [
       {
-        apr: 2,
-        selfApr: 1,
         link: 'https://example.com/active-merit',
-        startDate: daysFromNowIso(-1),
-        endDate: daysFromNowIso(1),
+        breakdowns: [
+          { campaignApr: 2, campaignId: 'base', campaignStartedAt: daysFromNowIso(-1), campaignEndedAt: daysFromNowIso(1) },
+          { campaignApr: 1, campaignId: 'self', campaignStartedAt: daysFromNowIso(-1), campaignEndedAt: daysFromNowIso(1) },
+        ],
       },
       {
-        apr: 10,
         link: 'https://example.com/past-merit',
-        startDate: daysFromNowIso(-10),
-        endDate: daysFromNowIso(-5),
+        breakdowns: [
+          { campaignApr: 10, campaignId: 'past', campaignStartedAt: daysFromNowIso(-10), campaignEndedAt: daysFromNowIso(-5) },
+        ],
       },
     ];
 

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -54,7 +54,7 @@ export const apyToApr = (apy: number): number => {
   return aprDecimal * 100;
 };
 
-import type { MeritIncentive, MerklOpportunityGroup, BrevisIncentive, ReserveWithSpread } from '@/types/aave';
+import type { MeritCampaignGroup, MerklOpportunityGroup, BrevisIncentive, ReserveWithSpread } from '@/types/aave';
 import { isCampaignActive } from '@/lib/campaignGroups';
 import { TYDRO_POINT_TO_USD_RATE, getMerklBreakdownApr } from '@/lib/tydro';
 import {
@@ -115,7 +115,7 @@ const sumNumberArrayApy = (arr?: number[]): number => {
 };
 
 export const calculateTotalIncentiveApr = (
-  meritIncentives?: MeritIncentive[],
+  meritIncentives?: MeritCampaignGroup[],
   merklOpportunities?: MerklOpportunityGroup[],
   brevisIncentives?: BrevisIncentive[],
   protocolIncentives?: number[],
@@ -131,7 +131,7 @@ export const calculateTotalIncentiveApr = (
 };
 
 export const calculateTotalIncentiveApy = (
-  meritIncentives?: MeritIncentive[],
+  meritIncentives?: MeritCampaignGroup[],
   merklOpportunities?: MerklOpportunityGroup[],
   brevisIncentives?: BrevisIncentive[],
   protocolIncentives?: number[],

--- a/src/lib/incentiveAggregation.test.ts
+++ b/src/lib/incentiveAggregation.test.ts
@@ -4,7 +4,7 @@ import {
   aggregateMerklOpportunityApr,
   aggregateBrevisIncentiveApr,
 } from './incentiveAggregation';
-import type { MeritIncentive, MerklOpportunityGroup, BrevisIncentive } from '@/types/aave';
+import type { MeritCampaignGroup, MerklOpportunityGroup, BrevisIncentive } from '@/types/aave';
 
 function daysFromNowIso(days: number): string {
   const d = new Date();
@@ -13,18 +13,29 @@ function daysFromNowIso(days: number): string {
 }
 
 describe('aggregateMeritIncentiveApr', () => {
-  it('sums apr + selfApr for active campaigns', () => {
-    const incentives: MeritIncentive[] = [
-      { apr: 3, selfApr: 2, link: 'https://example.com', startDate: daysFromNowIso(-1), endDate: daysFromNowIso(1) },
+  it('sums campaignApr for active breakdowns', () => {
+    const groups: MeritCampaignGroup[] = [
+      {
+        link: 'https://example.com',
+        breakdowns: [
+          { campaignApr: 3, campaignId: 'base', campaignStartedAt: daysFromNowIso(-1), campaignEndedAt: daysFromNowIso(1) },
+          { campaignApr: 2, campaignId: 'self', campaignStartedAt: daysFromNowIso(-1), campaignEndedAt: daysFromNowIso(1) },
+        ],
+      },
     ];
-    expect(aggregateMeritIncentiveApr(incentives)).toBe(5);
+    expect(aggregateMeritIncentiveApr(groups)).toBe(5);
   });
 
   it('excludes inactive campaigns', () => {
-    const incentives: MeritIncentive[] = [
-      { apr: 3, link: 'https://example.com', startDate: daysFromNowIso(-10), endDate: daysFromNowIso(-5) },
+    const groups: MeritCampaignGroup[] = [
+      {
+        link: 'https://example.com',
+        breakdowns: [
+          { campaignApr: 3, campaignId: 'base', campaignStartedAt: daysFromNowIso(-10), campaignEndedAt: daysFromNowIso(-5) },
+        ],
+      },
     ];
-    expect(aggregateMeritIncentiveApr(incentives)).toBe(0);
+    expect(aggregateMeritIncentiveApr(groups)).toBe(0);
   });
 
   it('returns 0 for undefined/empty', () => {
@@ -33,18 +44,29 @@ describe('aggregateMeritIncentiveApr', () => {
   });
 
   it('sanitizes NaN/negative values', () => {
-    const incentives: MeritIncentive[] = [
-      { apr: NaN, selfApr: -1, link: 'https://example.com', startDate: daysFromNowIso(-1), endDate: daysFromNowIso(1) },
+    const groups: MeritCampaignGroup[] = [
+      {
+        link: 'https://example.com',
+        breakdowns: [
+          { campaignApr: NaN, campaignId: 'a', campaignStartedAt: daysFromNowIso(-1), campaignEndedAt: daysFromNowIso(1) },
+          { campaignApr: -1, campaignId: 'b', campaignStartedAt: daysFromNowIso(-1), campaignEndedAt: daysFromNowIso(1) },
+        ],
+      },
     ];
-    expect(aggregateMeritIncentiveApr(incentives)).toBe(0);
+    expect(aggregateMeritIncentiveApr(groups)).toBe(0);
   });
 
   it('converts to APY when isApy is true', () => {
-    const incentives: MeritIncentive[] = [
-      { apr: 10, link: 'https://example.com', startDate: daysFromNowIso(-1), endDate: daysFromNowIso(1) },
+    const groups: MeritCampaignGroup[] = [
+      {
+        link: 'https://example.com',
+        breakdowns: [
+          { campaignApr: 10, campaignId: 'a', campaignStartedAt: daysFromNowIso(-1), campaignEndedAt: daysFromNowIso(1) },
+        ],
+      },
     ];
-    const apr = aggregateMeritIncentiveApr(incentives);
-    const apy = aggregateMeritIncentiveApr(incentives, { isApy: true });
+    const apr = aggregateMeritIncentiveApr(groups);
+    const apy = aggregateMeritIncentiveApr(groups, { isApy: true });
     expect(apy).toBeGreaterThan(apr);
   });
 });

--- a/src/lib/incentiveAggregation.ts
+++ b/src/lib/incentiveAggregation.ts
@@ -1,4 +1,4 @@
-import type { BrevisIncentive, MeritIncentive, MerklOpportunityGroup } from '@/types/aave';
+import type { BrevisIncentive, MeritCampaignGroup, MerklOpportunityGroup } from '@/types/aave';
 import { isCampaignActive, sumActiveCampaignBreakdownValues } from '@/lib/campaignGroups';
 import {
   getBrevisCampaignBreakdowns,
@@ -13,27 +13,24 @@ const sanitizePercent = (value: number): number =>
 
 export interface IncentiveAggregationOptions {
   isApy?: boolean;
-  /** Merkl campaign IDs the user opted into for whitelist-only APR */
   whitelistMerklCampaignIds?: ReadonlySet<string>;
-  /** Point-to-USD conversion rate for Merkl points campaigns */
   tydroPointToUsdRate?: number;
 }
 
 export function aggregateMeritIncentiveApr(
-  meritIncentives?: MeritIncentive[],
+  meritGroups?: MeritCampaignGroup[],
   options: IncentiveAggregationOptions = {},
 ): number {
-  if (!meritIncentives?.length) return 0;
   const { isApy = false } = options;
-  return meritIncentives.reduce((sum, incentive) => {
-    if (!isCampaignActive(incentive.startDate, incentive.endDate)) return sum;
-    const apr = sanitizePercent(incentive.apr);
-    const selfApr = sanitizePercent(incentive.selfApr ?? 0);
-    if (isApy) {
-      return sum + (apr > 0 ? convertAprToApy(apr) : 0) + (selfApr > 0 ? convertAprToApy(selfApr) : 0);
-    }
-    return sum + apr + selfApr;
-  }, 0);
+  return sumActiveCampaignBreakdownValues(meritGroups, {
+    getBreakdowns: (group) => group.breakdowns,
+    getStartDate: (_group, breakdown) => breakdown.campaignStartedAt,
+    getEndDate: (_group, breakdown) => breakdown.campaignEndedAt,
+    mapValue: (_group, breakdown) => {
+      const apr = sanitizePercent(breakdown.campaignApr);
+      return isApy && apr > 0 ? convertAprToApy(apr) : apr;
+    },
+  });
 }
 
 export function aggregateMerklOpportunityApr(

--- a/src/lib/meritForecast.test.ts
+++ b/src/lib/meritForecast.test.ts
@@ -14,6 +14,37 @@ describe('extractMeritSelfCapUsd', () => {
 
     expect(cap).toBe(1000);
   });
+
+  it('returns API positionCap directly when provided', () => {
+    const cap = extractMeritSelfCapUsd(undefined, 35000);
+    expect(cap).toBe(35000);
+  });
+
+  it('prefers API positionCap over message regex', () => {
+    const cap = extractMeritSelfCapUsd(
+      [
+        {
+          action: 'Self Authentication',
+          description: 'for the first $500 USDT',
+        },
+      ],
+      2000,
+    );
+    expect(cap).toBe(2000);
+  });
+
+  it('falls back to regex when API positionCap is not positive', () => {
+    const cap = extractMeritSelfCapUsd(
+      [
+        {
+          action: 'Self Authentication',
+          description: 'for the first $500 USDT',
+        },
+      ],
+      0,
+    );
+    expect(cap).toBe(500);
+  });
 });
 
 describe('forecastMeritCampaign', () => {

--- a/src/lib/meritForecast.ts
+++ b/src/lib/meritForecast.ts
@@ -1,8 +1,8 @@
-import type { IncentiveMessage, MeritIncentive } from '@/types/aave';
+import type { IncentiveMessage, MeritCampaignBreakdown, MeritCampaignGroup } from '@/types/aave';
 
 const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
-export type MeritMessage = MeritIncentive['message'];
+export type MeritMessage = IncentiveMessage;
 export type MeritForecastMode = 'MERIT_BASE' | 'MERIT_SELF_CAP';
 export type MeritForecastEstimateKind = MeritForecastMode | 'MERIT_CURRENT_RATE';
 
@@ -62,7 +62,16 @@ function flattenMessageLines(message?: MeritMessage): string[] {
     return message.flatMap((item) => flattenMessageLines(item as MeritMessage));
   }
   if (typeof message === 'object') {
-    return Object.values(message).flatMap((value) => flattenMessageLines(value as MeritMessage));
+    const rec = message as Record<string, unknown>;
+    const action = rec.action;
+    const description = rec.description;
+    if (typeof action === 'string' && typeof description === 'string') {
+      return [`${action} ${description}`];
+    }
+    if (typeof description === 'string') {
+      return [description];
+    }
+    return Object.values(rec).flatMap((value) => flattenMessageLines(value as MeritMessage));
   }
   return [];
 }
@@ -92,7 +101,10 @@ export function splitMeritMessageBySelfAuth(message?: MeritMessage): {
   };
 }
 
-export function extractMeritSelfCapUsd(message?: MeritMessage): number | null {
+export function extractMeritSelfCapUsd(message?: MeritMessage, apiPositionCap?: number): number | null {
+  if (typeof apiPositionCap === 'number' && Number.isFinite(apiPositionCap) && apiPositionCap > 0) {
+    return apiPositionCap;
+  }
   const lines = flattenMessageLines(message);
   for (const line of lines) {
     if (!line.toLowerCase().includes('self')) continue;
@@ -303,27 +315,37 @@ export function forecastMeritCampaign({
 }
 
 export function forecastMeritAprPercent(
-  incentive: MeritIncentive,
+  group: MeritCampaignGroup,
   depositUsd: number,
   anchorTvlUsd?: number,
 ): number {
   if (!Number.isFinite(depositUsd) || depositUsd <= 0) {
-    return sanitizePercent(incentive.apr) + sanitizePercent(incentive.selfApr);
+    return group.breakdowns.reduce((sum, bd) => sum + sanitizePercent(bd.campaignApr), 0);
   }
 
-  const baseAprPercent = sanitizePercent(incentive.apr);
-  const selfAprPercent = sanitizePercent(incentive.selfApr);
-  const { selfMessage } = splitMeritMessageBySelfAuth(incentive.message);
-  const selfCapUsd = extractMeritSelfCapUsd(selfMessage);
+  const selfBd = group.breakdowns.find((bd) => {
+    const msg = bd.message;
+    const text = typeof msg === 'string' ? msg.toLowerCase() : JSON.stringify(msg ?? '').toLowerCase();
+    return text.includes('self authentication');
+  });
+  const baseBreakdowns = group.breakdowns.filter((bd) => bd !== selfBd);
+
+  const baseAprPercent = baseBreakdowns.reduce((sum, bd) => sum + sanitizePercent(bd.campaignApr), 0);
+  const selfAprPercent = sanitizePercent(selfBd?.campaignApr ?? 0);
+  const { selfMessage } = splitMeritMessageBySelfAuth(selfBd?.message);
+  const selfCapUsd = extractMeritSelfCapUsd(selfMessage, selfBd?.positionCap);
+
+  const firstBd = baseBreakdowns[0] ?? selfBd;
+  const startDate = firstBd?.campaignStartedAt;
+  const endDate = firstBd?.campaignEndedAt;
 
   const baseForecast = baseAprPercent > 0
     ? forecastMeritCampaign({
         mode: 'MERIT_BASE',
         depositUsd,
         forecastAprPercent: baseAprPercent,
-        startDate: incentive.startDate,
-        endDate: incentive.endDate,
-        lastRoundRewardUsd: incentive.lastRoundRewardUsd,
+        startDate,
+        endDate,
         anchorTvlUsd,
       })
     : null;
@@ -334,10 +356,9 @@ export function forecastMeritAprPercent(
         depositUsd,
         forecastAprPercent: selfAprPercent,
         selfCapUsd: selfCapUsd ?? undefined,
-        startDate: incentive.startDate,
-        endDate: incentive.endDate,
+        startDate,
+        endDate,
         baseAprPercent: baseAprPercent > 0 ? baseAprPercent : undefined,
-        baseLastRoundRewardUsd: incentive.lastRoundRewardUsd,
         anchorTvlUsd,
       })
     : null;

--- a/src/types/aave.ts
+++ b/src/types/aave.ts
@@ -3,23 +3,12 @@ export type IncentiveMessage = string | IncentiveMessage[] | {
   [key: string]: IncentiveMessageScalar | IncentiveMessage;
 };
 
-// Merit incentive data structure
-export interface MeritIncentive {
-  apr: number;                         // APR percentage value (e.g., 5.2 means 5.2%)
-  selfApr?: number;                    // Self APR percentage value (if there's a corresponding self- prefixed key)
-  link: string;                        // Merit campaign detail page link
-  name?: string;                       // Merit campaign name (optional)
-  message?: IncentiveMessage;          // Merit campaign message/description (optional)
-  startDate: string;                   // Campaign start date
-  endDate: string;                     // Campaign end date
-  lastRoundRewardUsd?: number;         // Latest round total reward in USD
-}
-
 export interface BaseCampaignBreakdown {
   campaignApr: number;
   campaignStartedAt: string;
   campaignEndedAt: string;
   campaignId?: string;
+  positionCap?: number;
 }
 
 export interface CampaignGroup<TBreakdown extends BaseCampaignBreakdown = BaseCampaignBreakdown> {
@@ -29,14 +18,26 @@ export interface CampaignGroup<TBreakdown extends BaseCampaignBreakdown = BaseCa
   breakdowns: TBreakdown[];
 }
 
-// Merkl opportunity data structure
+export interface MeritCampaignBreakdown extends BaseCampaignBreakdown {
+  campaignId: string;
+  campaignType?: string;
+  message?: IncentiveMessage;
+  aprCap?: number | null;
+  rewardTokenSymbol?: string;
+  totalBudget?: number;
+  latestTvl?: number;
+}
+
+export interface MeritCampaignGroup extends Omit<CampaignGroup<MeritCampaignBreakdown>, 'message'> {
+  message?: IncentiveMessage;
+}
+
 export interface MerklCampaignBreakdown extends BaseCampaignBreakdown {
-  campaignId: string;                 // Campaign ID
-  whitelistOnly?: boolean;             // Merkl campaign is whitelist-only
-  pointsPerThousandUsd?: number;       // Tydro protocol points/1000USD value (optional)
+  campaignId: string;
+  whitelistOnly?: boolean;
+  pointsPerThousandUsd?: number;
   campaignType?: string;
   totalBudget?: number;
-  /** Max APR cap from API as percent points (e.g. 3.2 means 3.2%), same unit as `campaignApr`. */
   aprCap?: number | null;
   latestTvl?: number;
   plannedDaily?: number;
@@ -102,9 +103,8 @@ export interface ReserveWithSpread {
   supplyIncentives?: number[];
   borrowIncentives?: number[];
   
-  // Merit APR incentives (array of objects containing complete campaign information)
-  meritSupplys?: MeritIncentive[];
-  meritBorrows?: MeritIncentive[];
+  meritSupplys?: MeritCampaignGroup[];
+  meritBorrows?: MeritCampaignGroup[];
   
   // Merkl detailed opportunity data
   merklSupplys?: MerklOpportunityGroup[];

--- a/tasks/prd-target-total-apr-frontend.md
+++ b/tasks/prd-target-total-apr-frontend.md
@@ -1,0 +1,103 @@
+# PRD: TARGET_TOTAL_APR 前端适配
+
+## 需求背景
+
+Merkl 有一种 "Target Total APR" 分发模式：Merkl 只支付 `targetAPR - nativeAPR` 的差额，不是全额。后端已完成全部适配——campaign type 识别（Level 3 fallback）、breakdown/forecast 字段路由、API 输出 `campaignType: "TARGET_TOTAL_APR"` + `budgetBoundMode` + 转换后的 `campaignApr`。
+
+前端 `merklForecast.ts` 已有一个**部分实现**：`TARGET_TOTAL_APR` 被硬编码归入 `isFixAprCampaign`（行 58），但这忽略了 `budgetBoundMode` 维度。当前 3 个活跃 TARGET_TOTAL_APR campaign 全部是 `MAX_APR`，正在走错误的 FIX 路径。此外 `budgetBoundMode` 字段未在类型/Schema 中声明，`useRateSimulation.ts` 的 cap note 逻辑也不覆盖 `TARGET_TOTAL_APR`。
+
+## 目标与价值
+
+**目标：**
+- `TARGET_TOTAL_APR` 根据 `budgetBoundMode` 动态归入 MAX 或 FIX forecast 路径
+- `budgetBoundMode` 缺失时不做 forecast（`mergeForecastState` 返回 null）
+- `budgetBoundMode` 字段在 TypeScript 类型和 Zod schema 中声明
+- `useRateSimulation.ts` cap note 覆盖 `TARGET_TOTAL_APR`
+
+**价值：**
+- 修复 3 个活跃 campaign 的 forecast 模拟结果不准确问题
+- 前端与后端 API 语义对齐，支持未来 FIX_APR 类型 campaign
+- 用户在 simulation 中能看到正确的 cap note 提示
+
+## 名词解释
+
+- **TARGET_TOTAL_APR**：Merkl campaign type，Merkl 只补足 `targetAPR - nativeAPR` 差额
+- **budgetBoundMode**：TARGET_TOTAL_APR 独有的正交维度，`MAX_APR`（dilutive）或 `FIX_APR`（early-end）
+- **aprCap**：MAX/FIX 时为 Merkl 实付 APR 上限；TARGET_TOTAL_APR 时为总 APR 目标（targetAPR，含 native）
+- **campaignApr**：所有类型统一为 Merkl 实付 APR（后端已转换）
+
+## 适用范围
+
+- 适用：`src/lib/merklForecast.ts`、`src/hooks/useRateSimulation.ts`、`src/types/aave.ts`、`src/lib/apiSchemas.ts`
+- 适用：3 个活跃 TARGET_TOTAL_APR campaign（均为 MAX_APR）
+- 适用：未来 FIX_APR 类型 campaign
+
+## 非目标
+
+- 不包含 ERC4626 子类型支持（需 vaultAPR 数据源，当前不可用）
+- 不包含 `distributionMethod` / `rawDistributionMethod` 前端处理（后端已移除 Level 1，前端从未读取）
+- 不修改 `campaignApr` 计算逻辑（后端已做 APR↔APY 转换 + nativeAPY 减法）
+- 不修改后端代码
+
+## 功能需求
+
+- FR-1: `MerklCampaignBreakdown` 接口新增 `budgetBoundMode?: string` 字段
+- FR-2: `apiSchemas.ts` 的 `MerklCampaignBreakdownSchema` 新增 `budgetBoundMode: z.string().optional()`
+- FR-3: `MerklForecastState` 接口新增 `budgetBoundMode?: string` 字段
+- FR-4: `merklForecast.ts` 移除 `isFixAprCampaign` 中 `TARGET_TOTAL_APR` 的硬编码，改为按 `budgetBoundMode` 路由：`MAX_APR` → `isMaxAprCampaign`，`FIX_APR` → `isFixAprCampaign`
+- FR-5: `mergeForecastState` 透传 `budgetBoundMode`，当 `campaignType === 'TARGET_TOTAL_APR' && !budgetBoundMode` 时返回 `null`
+- FR-6: `useRateSimulation.ts` cap note 逻辑覆盖 `TARGET_TOTAL_APR`：`budgetBoundMode=MAX_APR` 走 MAX cap note（`APR_CAPPED` regime），`budgetBoundMode=FIX_APR` 走 FIX cap note（`fixRewardableDays`）
+- FR-7: 更新 `merklForecast.test.ts` 中 `TARGET_TOTAL_APR` 测试：替换单一 FIX 等价测试为 MAX_APR 走 MAX 路径、FIX_APR 走 FIX 路径、无 budgetBoundMode 返回 null 三个测试
+
+## 关键流程/交互说明
+
+**Forecast 路径路由流程：**
+
+1. `mergeForecastState(breakdown, forecastStates, pointRateMap)` 被调用
+2. 检查 `breakdown.campaignType === 'TARGET_TOTAL_APR' && !breakdown.budgetBoundMode` → 返回 `null`，不做 forecast
+3. 构建 `MerklForecastState`，包含 `budgetBoundMode`
+4. `forecastWithTVL(forecastState, tvl)` 中：
+   - `TARGET_TOTAL_APR + MAX_APR` → `isMaxAprCampaign = true` → 走 MAX 路径（dilutive, `requiredDaily`, `APR_CAPPED` regime）
+   - `TARGET_TOTAL_APR + FIX_APR` → `isFixAprCampaign = true` → 走 FIX 路径（early-end, `fixRewardableDays`）
+
+**Cap note 路由流程：**
+
+1. `useRateSimulation.ts` 构建 Merkl campaign detail rows
+2. `mergeForecastState` 返回 merged state
+3. 判断 `merklType` 和 `budgetBoundMode`：
+   - `TARGET_TOTAL_APR + MAX_APR` + `regime === 'APR_CAPPED'` → `buildMerklAprCeilingEffect()`
+   - `TARGET_TOTAL_APR + FIX_APR` + `fixRewardableDays` 存在 → `buildMerklFixPoolBudgetEffect()`
+
+**aprCap 语义：**
+
+- `aprCap` 在 `mergeForecastState` 中通过 `merklAprCapPercentToForecastDecimal(breakdown.aprCap)` 转为 decimal
+- TARGET_TOTAL_APR 的 `aprCap = targetAPR × 100`（API percent points），代表总 APR 目标
+- 在 forecast 计算中 `aprBasedDaily = tvl × aprCap / 365`，对于 MAX_APR 模式始终大于 `requiredDaily`（incentive 口径），不构成实际约束；仅在极端低 TVL 边界可能触发，但实际场景不出现
+
+## 风险与依赖
+
+**风险：**
+- `budgetBoundMode` 缺失时返回 null 可能导致用户看不到 forecast 模拟——但这是正确行为，因为路径不可确定
+- 当前代码 `merklForecast.ts:58` 已有硬编码实现，移除后需确保无其他代码依赖 `TARGET_TOTAL_APR` 归入 FIX 路径
+
+**依赖：**
+- 后端 API 已输出 `budgetBoundMode` 字段（已确认）
+- 后端 API 已对 `campaignApr` 做 APR↔APY 转换 + nativeAPY 减法（已确认）
+- 后端对 `MAX_APR` 输出 `plannedDaily` + `requiredDaily`，对 `FIX_APR` 省略 `plannedDaily`、不输出 `requiredDaily`（已确认）
+
+## 验收标准
+
+- [ ] `MerklCampaignBreakdown` 和 `MerklForecastState` 包含 `budgetBoundMode?: string` 字段
+- [ ] Zod schema 包含 `budgetBoundMode: z.string().optional()`
+- [ ] `merklForecast.ts` 中 `TARGET_TOTAL_APR` 不再硬编码到 `isFixAprCampaign`
+- [ ] `TARGET_TOTAL_APR + MAX_APR` 走 MAX 路径（`APR_CAPPED`/`CATCHING_UP`/`PLANNED`）
+- [ ] `TARGET_TOTAL_APR + FIX_APR` 走 FIX 路径（`PLANNED` + `fixRewardableDays`）
+- [ ] `TARGET_TOTAL_APR` 无 `budgetBoundMode` 时 `mergeForecastState` 返回 null
+- [ ] `useRateSimulation.ts` cap note 覆盖 `TARGET_TOTAL_APR`（MAX_APR → APR ceiling，FIX_APR → fix budget）
+- [ ] `merklForecast.test.ts` 包含三个新测试（MAX_APR 路径、FIX_APR 路径、无 budgetBoundMode）
+- [ ] `useRateSimulation.test.ts` 包含 TARGET_TOTAL_APR cap note 测试
+- [ ] `npm run lint` 和 `npm run build` 通过
+
+## 待确认问题
+
+- 无（Grill session 已全部确认）


### PR DESCRIPTION
Previously the workflow retried enablePullRequestAutoMerge 5 times (up to 10 min) when PR was unstable, always failing. Now:\n\n- Detect failed checks during poll phase and skip the API call entirely\n- Only call enablePullRequestAutoMerge when all checks passed\n- If unstable due to transient race, log notice instead of erroring — next check_suite event will retry\n\nAlso includes npm audit fix (0 vulnerabilities).