### PR TITLE
fix: handle 422 race in delete-branch-on-merge + protect lovable

### DIFF
--- a/.github/workflows/delete-branch-on-merge.yml
+++ b/.github/workflows/delete-branch-on-merge.yml
@@ -1,4 +1,4 @@
-# 在带 automerge 标签的 PR 合并后删除 head 分支（与 automerge.yml 一致）；dev 与默认分支永不删除
+# 在带 automerge 标签的 PR 合并后删除 head 分支（与 automerge.yml 一致）；dev 与 lovable 永不删除
 name: Delete branch on merge
 
 on:
@@ -12,6 +12,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.event.repository.full_name &&
       github.event.pull_request.head.ref != github.event.repository.default_branch &&
       github.event.pull_request.head.ref != 'dev' &&
+      github.event.pull_request.head.ref != 'lovable' &&
       contains(github.event.pull_request.labels.*.name, 'automerge')
     runs-on: ubuntu-latest
     permissions:
@@ -23,9 +24,17 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const ref = `heads/${context.payload.pull_request.head.ref}`;
-            await github.rest.git.deleteRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref,
-            });
-            core.info(`Deleted branch ref: ${ref}`);
+            try {
+              await github.rest.git.deleteRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref,
+              });
+              core.info(`Deleted branch ref: ${ref}`);
+            } catch (error) {
+              if (error.status === 422) {
+                core.info(`Branch ${ref} already deleted — likely by GitHub auto-delete on merge.`);
+              } else {
+                throw error;
+              }
+            }


### PR DESCRIPTION
Two changes to `delete-branch-on-merge.yml`:

1. **422 race condition fix**: GitHub squash merge can auto-delete the branch before our workflow runs, causing `deleteRef` to fail with 422. Added try/catch to gracefully handle this.

2. **Protect lovable branch**: Added `lovable` to the never-delete list alongside `dev`, since lovable is a long-lived dev branch.