### PR TITLE
Merge lovable into dev — fix GithubIcon deploy failure

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,7 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action/*"

--- a/docs/adr/0024-main-required-status-checks-expansion.md
+++ b/docs/adr/0024-main-required-status-checks-expansion.md
@@ -1,0 +1,40 @@
+# ADR 0024: Expand Main Branch Required Status Checks
+
+## Status
+
+Accepted
+
+## Context
+
+Main branch previously had 5 required status checks: `lint`, `build`, `Analyze (javascript-typescript)`, `peer-dep-check`, `security-audit`. CodeQL and Socket Security checks were running on every PR but were not required — a PR could merge even if CodeQL found vulnerabilities or Socket Security flagged supply chain issues.
+
+Additionally, `required_approving_review_count` was 0 on both `main` and `dev`, meaning no review approval is needed. The `GITHUB_TOKEN` approve in `hardcode-sync.yml` is therefore a no-op for branch protection purposes (though it does add a visual review record on the PR).
+
+## Decision
+
+1. Add 3 new required status checks to `main` branch protection:
+   - `CodeQL` — CodeQL static analysis (runs in `.github/workflows/codeql.yml`)
+   - `Socket Security: Project Report` — Socket supply chain security audit
+   - `Socket Security: Pull Request Alerts` — Socket dependency alerts per PR
+
+2. Full required checks list after change:
+   - `lint`
+   - `build`
+   - `Analyze (javascript-typescript)`
+   - `peer-dep-check`
+   - `security-audit`
+   - `CodeQL`
+   - `Socket Security: Project Report`
+   - `Socket Security: Pull Request Alerts`
+
+3. No changes to `dev` branch protection (has no required checks or review requirements).
+
+## Consequences
+
+- Dependabot PRs that only upgrade one of three CodeQL action steps will fail (version mismatch). These must be closed and replaced with a single commit upgrading all three steps together.
+- PRs to `main` now require 8 checks to pass before auto-merge can complete.
+- This change was applied via GitHub API (`POST /branches/main/protection/required_status_checks/contexts`), not via code commit.
+
+## Date
+
+2026-07-08

--- a/docs/stash-analysis-PENDING.md
+++ b/docs/stash-analysis-PENDING.md
@@ -1,0 +1,210 @@
+# Pending Stash Analysis
+
+Three stashes contain unfinished work directions that need review before deciding whether to implement or discard.
+
+---
+
+## Stash 0: IncentiveTooltip grid→inline-flex layout
+
+**Stash message**: `WIP: IncentiveTooltip grid→inline-flex layout`
+
+**Files changed**:
+- `src/components/dashboard/IncentiveTooltip.tsx` (91 lines changed)
+- `src/components/dashboard/IncentiveTooltip.test.tsx` (8 lines changed)
+
+### What it does
+
+Replaces `grid grid-cols-[1fr_5rem]` layout with `flex` + `ml-auto` for APR alignment between opportunity headers and campaign rows in the IncentiveTooltip.
+
+**Before (current)**: Source header and campaign rows use `grid grid-cols-[1fr_5rem]` — fixed 5rem column for APR values.
+
+**After (stash)**: Uses `flex items-start gap-x-[var(--ds-space-1-5)]` + `ml-auto` on the APR `<span>` — APR values right-align via flex auto margin instead of grid column.
+
+### Why it was started
+
+User preference: arrow gap between text and APR should stay consistent when text wraps to multiple lines. Grid with fixed `5rem` column causes the APR to always start at the same horizontal position regardless of text length, which creates inconsistent visual spacing when text wraps.
+
+### Current state
+
+**Partially adopted**: Current lovable code already uses `ml-auto` and `inline-flex` in some places (source header APR, campaign APR), but still retains `grid grid-cols-[1fr_5rem]` in other rows (RecentlyEndedSection header, campaign date+APR rows). The stash is a more aggressive full replacement.
+
+### Key decisions needed
+
+1. Should the full IncentiveTooltip switch from grid to flex layout, or is the current hybrid (flex for some rows, grid for others) acceptable?
+2. The stash removes the fixed `5rem` column width — this means APR values no longer align vertically at a fixed position. Is this acceptable for visual consistency?
+
+### Diff summary
+
+```diff
+- <div className="grid grid-cols-[1fr_5rem] items-center gap-x-[var(--ds-space-1-5)] mb-[var(--ds-space-1)]">
++ <div className="flex items-center gap-x-[var(--ds-space-1-5)] mb-[var(--ds-space-1)]">
+
+- <span className="... justify-self-end">
++ <span className="... ml-auto">
+
+- <div className="ds-tooltip-body grid grid-cols-[1fr_5rem] items-start gap-x-[var(--ds-space-1-5)]">
++ <div className="ds-tooltip-body flex items-start gap-x-[var(--ds-space-1-5)]">
+
+- <span className="break-words min-w-0 flex items-center gap-1.5">
++ <span className="break-words min-w-0 inline-flex flex-wrap items-center gap-1.5">
+```
+
+---
+
+## Stash 1: ReservesTable crossReservePositions simplification
+
+**Stash message**: `WIP: ReservesTable crossReservePositions simplification`
+
+**Files changed**:
+- `src/components/dashboard/ReservesTable.tsx` (7 insertions, 19 deletions)
+
+### What it does
+
+Replaces the full `crossReservePositions` useMemo computation with a simple `return undefined`.
+
+**Before (current)**: In shared scenario mode, `crossReservePositions` builds a Map of per-reserve supplyUsd/borrowUsd from the shared input. In portfolio mode, returns `undefined` (portfolio passes its own map via `perReserveInputs`).
+
+**After (stash)**: Always returns `undefined`, regardless of mode. The comment explains:
+> Only portfolio mode builds crossReservePositions (from actual wallet positions). Shared scenario mode returns undefined — the same input copied to all reserves would cause incorrect cross-reserve offset calculations (AAV-1035).
+
+### Why it was started
+
+AAV-1035: In shared scenario mode, the same input amount is copied to every reserve. This causes cross-reserve offset calculations (e.g., Merkl scoring) to incorrectly count the same $1,000 borrow multiple times — once per reserve. The fix: shared scenario mode should not build crossReservePositions at all.
+
+### Current state
+
+**Not adopted**: Current lovable code still has the full computation. The `if (!isPortfolioMode) return undefined;` guard already skips shared scenario mode, so the AAV-1035 issue is already fixed in the current code. The stash goes further by removing the dead code path entirely.
+
+### Key decisions needed
+
+1. The current `if (!isPortfolioMode) return undefined;` guard already prevents the bug. Is it worth removing the dead code path (the 15 lines that build the map from shared inputs)?
+2. If removed, the `reserveSymbolById` memo that depends on `crossReservePositions` will also always return `undefined` — verify this has no side effects on Merkl cross-reserve note display.
+
+### Diff summary
+
+```diff
+  const crossReservePositions = useMemo((): Map<string, ReservePositions> | undefined => {
+-    if (!isPortfolioMode) return undefined;
+-    const rawSupply = parseNumberInput(debouncedSharedSupplyInput);
+-    const rawBorrow = parseNumberInput(debouncedSharedBorrowInput);
+-    if (rawSupply === 0 && rawBorrow === 0) return undefined;
+-    const map = new Map<string, ReservePositions>();
+-    for (const r of reserves) {
+-      const tp = r.tokenPrice ?? 0;
+-      const supplyUsd = sharedInputMode === 'usd' ? rawSupply : rawSupply * tp;
+-      const borrowUsd = sharedInputMode === 'usd' ? rawBorrow : rawBorrow * tp;
+-      if (supplyUsd > 0 || borrowUsd > 0) {
+-        map.set(r.reserveId, { supplyUsd, borrowUsd });
+-      }
+-    }
+-    return map.size > 0 ? map : undefined;
+-  }, [reserves, debouncedSharedSupplyInput, debouncedSharedBorrowInput, sharedInputMode, isPortfolioMode]);
++    // Only portfolio mode builds crossReservePositions (from actual wallet positions).
++    // Shared scenario mode returns undefined — the same input copied to all reserves
++    // would cause incorrect cross-reserve offset calculations (AAV-1035).
++    // In portfolio mode, shared inputs are empty strings, so rawSupply/rawBorrow are 0.
++    // The map is built from portfolioEntries via perReserveInputs instead.
++    return undefined;
++  }, []);
+```
+
+---
+
+## Stash 2: E1a portfolio code review fixes + reservesSorter disabled sort
+
+**Stash message**: `WIP: E1a portfolio code review fixes + reservesSorter disabled sort`
+
+**Files changed**:
+- `public/openapi.json` (3766 lines changed — spec format change, can be ignored)
+- `src/components/dashboard/PortfolioResultsTable.tsx` (29 lines changed)
+- `src/components/dashboard/PortfolioTokenRow.render.test.tsx` (30 lines changed)
+- `src/components/dashboard/PortfolioTokenRow.tsx` (6 lines changed)
+- `src/lib/reservesSorter.test.ts` (14 lines changed)
+- `src/lib/reservesSorter.ts` (13 lines changed)
+
+### What it does — three separate changes bundled together
+
+#### Change A: PortfolioResultsTable semantic colors
+
+Adds `accentClass` prop to `DeltaCell` and `ResultRow`, using `ds-text-emerald-600` for supply deltas and `ds-text-brand-cyan` for borrow deltas. Total percent column uses side-specific colors instead of generic `text-foreground`. Daily earn column uses `dayColor` (emerald for positive, destructive for negative, muted for zero).
+
+**Before**: All delta cells use `text-foreground/70`. Total percent uses `font-bold text-foreground`.
+
+**After**: Delta cells inherit accent class from their side. Total percent uses side-specific color. Daily earn uses conditional coloring.
+
+#### Change B: PortfolioTokenRow token input mode fix
+
+Fixes wallet display in token input mode — when `inputMode === 'token'` and `tokenPriceInUsd` is available, wallet value should be divided by token price to show token amount instead of USD amount.
+
+Also changes `text-[rgb(var(--ds-brand-cyan-rgb))]` → `ds-text-brand-cyan` (design token consistency), and arrow color `text-border` → `text-muted-foreground/40`.
+
+**Note**: The `ds-text-brand-cyan` change is **already adopted** in current lovable code. The token price division and arrow color change are not.
+
+#### Change C: reservesSorter disabled sort
+
+Adds `isSupplyDisabled` and `isBorrowDisabled` to `ReserveSortValueGetters` interface. Disabled reserves sort to the bottom in desc order (and top in asc order). This ensures frozen/paused/disabled reserves don't clutter the top of the table when sorting by highest APR.
+
+### Current state
+
+- **Change A**: Not adopted — PortfolioResultsTable still uses generic `text-foreground/70`
+- **Change B**: Partially adopted — `ds-text-brand-cyan` is in, but token input wallet display fix and arrow color are not
+- **Change C**: Not adopted — reservesSorter does not have `isSupplyDisabled`/`isBorrowDisabled`
+
+### Key decisions needed
+
+1. **Change A**: Should delta cells in PortfolioResultsTable use side-specific colors? This matches the PortfolioTokenRow convention but makes the results table more colorful.
+2. **Change B**: The token input wallet display fix is a bug — in token mode, wallet shows USD value instead of token amount. Is this the right fix? Also, `formatDeltaUsdDay` now uses `Math.abs(value)` — is this intentional?
+3. **Change C**: Should disabled/frozen reserves sort to the bottom? This is a UX improvement but adds two new interface methods to `ReserveSortValueGetters`, affecting all callers.
+
+### Diff summary for each change
+
+**Change A — PortfolioResultsTable accent colors**:
+```diff
+- <td className={cn('... text-foreground/70', ...)}>
++ <td className={cn('... ', value ? accentClass : 'text-muted-foreground', ...)}>
+
+- <td className={cn('... font-bold text-foreground', ...)}>
++ <td className={cn('... font-bold ', isBorrow ? 'ds-text-brand-cyan' : 'ds-text-emerald-600', ...)}>
+```
+
+**Change B — PortfolioTokenRow token input fix**:
+```diff
+- : formatNumberInput(formatConvertedAmount(sideData.walletValue!));
++ : (tokenPriceInUsd != null ? formatNumberInput(formatConvertedAmount(sideData.walletValue! / tokenPriceInUsd)) : formatNumberInput(formatConvertedAmount(sideData.walletValue!)));
+
+- <span className="text-border">→</span>
++ <span className="text-muted-foreground/40">→</span>
+
+- const prefix = value > 0 ? '+' : '';
+- return `${prefix}$${value.toFixed(2)}`;
++ const prefix = value > 0 ? '+' : '';
++ return `${prefix}$${Math.abs(value).toFixed(2)}`;
+```
+
+**Change C — reservesSorter disabled sort**:
+```diff
++ isSupplyDisabled: (reserve: R) => boolean;
++ isBorrowDisabled: (reserve: R) => boolean;
+
++ const aDisabled = isDisabled(a);
++ const bDisabled = isDisabled(b);
++ if (aDisabled !== bDisabled) {
++   return order === 'desc' ? (aDisabled ? 1 : -1) : (aDisabled ? -1 : 1);
++ }
+```
+
+---
+
+## Working tree WIP files (not in stash)
+
+These files are also pending in the working tree:
+
+| File | Description | Status |
+|------|-------------|--------|
+| `src/components/dashboard/PortfolioPanel.tsx` | Adds `?unified=1` query param mode that renders `PortfolioUnifiedTable` instead of split entry list + results table | Modified, 17 insertions, 6 deletions |
+| `src/components/dashboard/PortfolioUnifiedTable.tsx` | New 740-line component — unified input + results + summary in one table | Untracked, incomplete (parse error on line 740) |
+| `src/pages/Index.tsx` | `GithubIcon` → `Github` — **regression**, contradicts lucide-react 1.x upgrade | Modified, should revert |
+| `public/openapi.json` | Spec format change (inline → $ref or reverse) | Modified, should let CI sync |
+| `scripts/inspect-unified.ts` | Dev helper script for unified table | Untracked |
+| `scripts/screenshot-unified.ts` | Dev helper script for unified table | Untracked |
+| `修复 bot PR auto-merge(unstable-status 竞态根因).md` | Temporary document | Untracked, should delete |

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -29,7 +29,7 @@ import LoadingState from '@/components/dashboard/LoadingState';
 import PullToRefresh from '@/components/dashboard/PullToRefresh';
 import { getCachedMarkets, setCachedTydroRate } from '@/lib/cache';
 import { TYDRO_POINT_TO_USD_RATE, buildPointRateMap } from '@/lib/tydro';
-import { AlertTriangle, Send, GithubIcon } from 'lucide-react';
+import { AlertTriangle, Send } from 'lucide-react';
 import { toast } from 'sonner';
 import {
   preloadIncentiveIcons,
@@ -762,7 +762,7 @@ const Index = () => {
                   title="View source on GitHub"
                   className="flex items-center justify-center w-[var(--ds-control-h)] h-[var(--ds-control-h)] rounded-full border border-border/40 bg-card/60 text-muted-foreground transition-colors hover:bg-muted/80 hover:text-foreground hover:border-border focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                 >
-                  <GithubIcon className="w-4 h-4" />
+                  <svg className="w-4 h-4" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
                 </a>
               </div>
             </div>


### PR DESCRIPTION
Replace `GithubIcon` import with inline GitHub SVG. lucide-react 1.x removed the `Github` icon due to trademark policy, causing Vercel build failures.