### PR TITLE
sync: lovable → dev (canonical fix + AAV-1137 + wallet derivation refactor)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,8 +174,30 @@ jobs:
           LIVE_TEST_API_BASE: ${{ vars.LIVE_TEST_API_BASE_CI != '' && vars.LIVE_TEST_API_BASE_CI || 'https://staging-api.aaveapy.com/api' }}
           RUN_LIVE_TESTS: "true"
         run: bash scripts/ci-live-schema-validate.sh
-
-  openapi-check:
+  live-simulation-validation:
+    name: live-simulation-validation
+    if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/lovable') && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    env:
+      CI_REF: ${{ github.event.pull_request.head.sha || github.event.inputs.target_ref || github.sha }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ env.CI_REF }}
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+          cache: npm
+      - name: Install dependencies
+        run: npm run ci:lockcheck
+      - name: Run simulation Golden Rule tests against staging API
+        env:
+          LIVE_TEST_API_BASE: ${{ vars.LIVE_TEST_API_BASE_CI != '' && vars.LIVE_TEST_API_BASE_CI || 'https://staging-api.aaveapy.com/api' }}
+          RUN_LIVE_TESTS: "true"
+        run: npm run test:live:simulation:staging  openapi-check:
     name: openapi-check
     runs-on: ubuntu-latest
     env:

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ output/
 
 # Local-only notes and drafts (not committed)
 /local/
+.vercel

--- a/docs/lessons/rate-simulation.md
+++ b/docs/lessons/rate-simulation.md
@@ -134,3 +134,10 @@ Historical lessons from working on `rateSimulationCalculator.ts` and related inc
 - **修复：用 `rawBorrowInputUsd`/`rawSupplyInputUsd` 代替 capped 值**：`walletBorrowUsd = totalBorrowUsd - rawBorrowInputUsd`，因为 `totalBorrowUsd = wallet + rawDelta`，所以 `wallet = total - rawDelta`。capped 值仅用于利率模拟（你不能借超过 cap 的量），但 wallet 推导必须用未截断的原始输入。
 - **TDD 验证方式**：设置两个 Portfolio 场景（同一 wallet，一个 delta 在 cap 内、一个超出 cap），验证 `currentIncentive` 完全相同。Bug 存在时差异 = 10% × (0.444 - 0.375) ≈ 0.69%，远超浮点误差容限。
 - **真实数据验证**：新增 `rateSimulationCalculator.live.test.ts`，对 staging API 所有有 incentive 的 reserve 验证 Golden Rules（currentIncentive = per-source sum、current* 不变性、AAV-1120 cap 不变性）。通过 `npm run test:live:simulation:staging` 运行。
+
+## 移除 wallet 倒推 fallback，改为显式传参 (AAV-1140)
+- **倒推计算是结构性风险**：AAV-1120 修复了 capped input 导致的微误差，但倒推逻辑本身（`wallet = total - rawInput`）仍然脆弱——任何 `totalSupplyUsd` 或 `rawInputUsd` 的计算变更都可能引入新的偏差。根本问题是：caller (`buildPerReserveInputsFromEntries`) 已经有 `walletValue` 的显式值，但在构建 `PerReserveInput` 时丢弃了它，只传 `totalSupplyUsd`（wallet + delta），让 calculator 倒推。
+- **修复：显式传参消除倒推**：在 `PerReserveInput` 新增 `walletSupplyUsd?`/`walletBorrowUsd?` 字段，`buildPerReserveInputsFromEntries` 和 `buildGroupMapFromSlots` 在遍历 entries 时累加 `s.walletValue`（仅当 `walletValue !== null && walletValue > 0`），初始值 `undefined`（不是 `0`，以区分"无钱包"和"钱包为零"）。Calculator 直接使用 `explicitWalletSupplyUsd`/`explicitWalletBorrowUsd`，删除所有倒推代码。
+- **测试影响范围**：~25 个单元测试和 5 个 live API 测试原先依赖 fallback（传 `totalSupplyUsd` 不传 `walletSupplyUsd`），需要逐个添加显式 wallet 值。部分测试"碰巧通过"（wallet=undefined → 无 dilution → current=10，与期望值相同），但语义错误——测试注释说"wallet=$5000"但实际无 wallet。修复时一并更新这些测试。
+- **Spec 文档**：`docs/specs/wallet-position-explicit-passing.md`
+- **涉及文件**：`portfolioSimulator.ts`（PerReserveInput + EntryGroup + buildPerReserveInputsFromEntries + buildGroupMapFromSlots + computeResultsFromGroups）、`useRateSimulation.ts`、`rateSimulationCalculator.ts`、3 个测试文件。

--- a/docs/specs/wallet-position-explicit-passing.md
+++ b/docs/specs/wallet-position-explicit-passing.md
@@ -1,0 +1,147 @@
+# Spec: Wallet Position Explicit Passing (Eliminate Reverse Derivation)
+
+## Status
+
+Draft
+
+## Context
+
+### Problem
+
+`buildRateSimulationResult` derives wallet positions by reverse calculation:
+
+```typescript
+const walletSupplyUsd = explicitWalletSupplyUsd ?? (totalSupplyUsd != null
+    ? totalSupplyUsd - rawSupplyInputUsd : undefined);
+const walletBorrowUsd = explicitWalletBorrowUsd ?? (totalBorrowUsd != null
+    ? totalBorrowUsd - rawBorrowInputUsd : undefined);
+```
+
+This fallback is fragile:
+- AAV-1120 was caused by using capped `borrowInputUsd` instead of `rawBorrowInputUsd` in this derivation
+- The caller (`buildPerReserveInputsFromEntries`) already has `walletValue` explicitly but discards it, only passing `totalSupplyUsd` (wallet + delta) and `supplyInput` (delta)
+- The calculator's `BuildRateSimulationResultParams` already has `walletSupplyUsd`/`walletBorrowUsd` parameters (added in AAV-771), but no production caller uses them
+
+### Design Decision (Grill Session Conclusions)
+
+1. **ADR-009 Alternative A does not conflict**: ADR-009 rejected "calculator internally looks up walletValue from context", not "caller explicitly passes walletValue parameter". Calculator remains a pure function.
+
+2. **Remove fallback entirely**: `walletSupplyUsd`/`walletBorrowUsd` only from explicit parameters. No reverse derivation. This structurally prevents AAV-1120-class bugs.
+
+3. **Manual entry (`walletValue = null`) → `undefined`**: When no wallet position exists, pass `undefined` (not `0`). Calculator's `hasWallet` check uses `!= null`, so `undefined` correctly triggers identity fallback (Golden Rule §3).
+
+4. **Mixed wallet + manual entries on same reserveId**: Accumulate wallet values only from entries where `walletValue !== null`. Manual entries contribute to `totalSupplyUsd`/`totalBorrowUsd` but not to `walletSupplyUsd`/`walletBorrowUsd`.
+
+5. **Live API tests must pass wallet values explicitly**: Tests that rely on fallback are testing the wrong path. Update them to pass `walletSupplyUsd`/`walletBorrowUsd` directly.
+
+6. **AAV-1137 (cross-reserve wallet positions) is out of scope**: Pre-existing bug where `walletCrossReservePositions` uses total values for non-self reserves. Tracked separately.
+
+## Changes
+
+### 1. `PerReserveInput` interface (`portfolioSimulator.ts`)
+
+Add two optional fields:
+
+```typescript
+export interface PerReserveInput {
+  supplyInput: string;
+  borrowInput: string;
+  inputMode: ScenarioInputMode;
+  totalSupplyUsd?: number;
+  totalBorrowUsd?: number;
+  walletSupplyUsd?: number;  // NEW: wallet-only supply position
+  walletBorrowUsd?: number;  // NEW: wallet-only borrow position
+}
+```
+
+### 2. `buildPerReserveInputsFromEntries` (`portfolioSimulator.ts`)
+
+Extend grouped structure to track wallet values:
+
+```typescript
+const grouped = new Map<string, {
+  supplyUsd: number;
+  borrowUsd: number;
+  supplyDeltaUsd: number;
+  borrowDeltaUsd: number;
+  walletSupplyUsd: number | undefined;  // NEW
+  walletBorrowUsd: number | undefined;  // NEW
+}>();
+```
+
+Accumulation logic: only accumulate `s.walletValue` when `s.walletValue !== null && s.walletValue > 0`. Initial value `undefined` (not `0`) to distinguish "no wallet" from "wallet is zero".
+
+Output:
+
+```typescript
+perReserveInputs.set(reserveId, {
+  supplyInput: String(group.supplyDeltaUsd),
+  borrowInput: String(group.borrowDeltaUsd),
+  inputMode: 'usd',
+  totalSupplyUsd: group.supplyUsd,
+  totalBorrowUsd: group.borrowUsd,
+  walletSupplyUsd: group.walletSupplyUsd,   // NEW
+  walletBorrowUsd: group.walletBorrowUsd,   // NEW
+});
+```
+
+### 3. `useRateSimulation.ts` (call site 1)
+
+Pass wallet values from `perReserveInputs`:
+
+```typescript
+buildRateSimulationResult({
+  // ... existing params ...
+  totalSupplyUsd: effectiveTotalSupplyUsd,
+  totalBorrowUsd: effectiveTotalBorrowUsd,
+  walletSupplyUsd: perReserve?.walletSupplyUsd,   // NEW
+  walletBorrowUsd: perReserve?.walletBorrowUsd,   // NEW
+});
+```
+
+### 4. `portfolioSimulator.ts` `simulatePortfolioFromEntries` (call site 2)
+
+Pass wallet values from group:
+
+```typescript
+buildRateSimulationResult({
+  // ... existing params ...
+  totalSupplyUsd: group.supplyUsd,
+  totalBorrowUsd: group.borrowUsd,
+  walletSupplyUsd: group.walletSupplyUsd,   // NEW
+  walletBorrowUsd: group.walletBorrowUsd,   // NEW
+});
+```
+
+### 5. `rateSimulationCalculator.ts` (remove fallback)
+
+```typescript
+// BEFORE (with fallback):
+const walletSupplyUsd = explicitWalletSupplyUsd ?? (totalSupplyUsd != null
+    ? totalSupplyUsd - rawSupplyInputUsd : undefined);
+const walletBorrowUsd = explicitWalletBorrowUsd ?? (totalBorrowUsd != null
+    ? totalBorrowUsd - rawBorrowInputUsd : undefined);
+
+// AFTER (direct use only):
+const walletSupplyUsd = explicitWalletSupplyUsd;
+const walletBorrowUsd = explicitWalletBorrowUsd;
+```
+
+### 6. Test updates
+
+- `rateSimulationCalculator.test.ts`: ~25 tests that pass `totalSupplyUsd` without `walletSupplyUsd` need explicit wallet values added
+- `rateSimulationCalculator.live.test.ts`: 5 test scenarios need `walletSupplyUsd`/`walletBorrowUsd` passed explicitly
+- `portfolioSimulator.test.ts`: `toEqual` assertions need `walletSupplyUsd`/`walletBorrowUsd` fields added to expected objects
+
+## Verification
+
+- TDD: red → green → refactor per ticket
+- Validation gate: `npm run lint && npm test && npm run build && npx tsc --noEmit`
+- Live API tests: `npm run test:live:simulation:staging`
+- Dev server + Playwright: verify Portfolio mode UI renders correctly with wallet positions
+
+## Out of Scope
+
+- AAV-1137: `walletCrossReservePositions` uses total for non-self reserves (separate issue)
+- `crossReservePositions` map remains total-based (correct for after/simulation values)
+- Single Mode path unaffected (no `perReserveInputs`, wallet values are `undefined` → identity)

--- a/src/components/dashboard/ReservesTable.tsx
+++ b/src/components/dashboard/ReservesTable.tsx
@@ -247,6 +247,7 @@ const ReservesTable = ({
   );
   const perReserveInputs = portfolioInputsResult?.perReserveInputs;
   const crossReservePositions = portfolioInputsResult?.crossReservePositions;
+  const walletCrossReservePositions = portfolioInputsResult?.walletCrossReservePositions;
   const reserveSymbolById = portfolioInputsResult?.reserveSymbolById;
 
   const { simulationsById, hasAnyInput: hasScenarioInput } = useSharedRateSimulations({
@@ -260,6 +261,7 @@ const ReservesTable = ({
     inputMode: sharedInputMode,
     meritMerklNetPosition,
     crossReservePositions,
+    walletCrossReservePositions,
     reserveSymbolById,
     perReserveInputs,
   });

--- a/src/hooks/useRateSimulation.ts
+++ b/src/hooks/useRateSimulation.ts
@@ -295,6 +295,8 @@ export const useSharedRateSimulations = ({
       // always receives an explicit total position (or undefined when no input).
       const effectiveTotalSupplyUsd = perReserve?.totalSupplyUsd;
       const effectiveTotalBorrowUsd = perReserve?.totalBorrowUsd;
+      const effectiveWalletSupplyUsd = perReserve?.walletSupplyUsd;
+      const effectiveWalletBorrowUsd = perReserve?.walletBorrowUsd;
 
       acc[reserveId] = {
         ...buildRateSimulationResult({
@@ -315,6 +317,8 @@ export const useSharedRateSimulations = ({
           hubBorrowed,
           totalSupplyUsd: effectiveTotalSupplyUsd,
           totalBorrowUsd: effectiveTotalBorrowUsd,
+          walletSupplyUsd: effectiveWalletSupplyUsd,
+          walletBorrowUsd: effectiveWalletBorrowUsd,
           pointRateMap,
         }),
         tokenPriceLoading: tokenPriceLoadingById[reserveId] ?? false,

--- a/src/hooks/useRateSimulation.ts
+++ b/src/hooks/useRateSimulation.ts
@@ -62,6 +62,7 @@ interface UseRateSimulationParams {
   inputMode?: ScenarioInputMode;
   meritMerklNetPosition?: boolean;
   crossReservePositions?: Map<string, ReservePositions>;
+  walletCrossReservePositions?: Map<string, ReservePositions>;
   reserveSymbolById?: Map<string, string>;
 }
 
@@ -77,6 +78,7 @@ interface UseSharedRateSimulationsParams {
   inputMode?: ScenarioInputMode;
   meritMerklNetPosition?: boolean;
   crossReservePositions?: Map<string, ReservePositions>;
+  walletCrossReservePositions?: Map<string, ReservePositions>;
   reserveSymbolById?: Map<string, string>;
   perReserveInputs?: Map<string, PerReserveInput>;
 }
@@ -93,6 +95,7 @@ export const useSharedRateSimulations = ({
   inputMode = 'token',
   meritMerklNetPosition = true,
   crossReservePositions,
+  walletCrossReservePositions,
   reserveSymbolById,
   perReserveInputs,
 }: UseSharedRateSimulationsParams) => {
@@ -312,6 +315,7 @@ export const useSharedRateSimulations = ({
           forecastStates,
           meritMerklNetPosition,
           crossReservePositions,
+          walletCrossReservePositions,
           reserveSymbolById,
           hubSupplied,
           hubBorrowed,
@@ -344,6 +348,7 @@ export const useSharedRateSimulations = ({
     tydroPointToUsdRate,
     pointRateMap,
     crossReservePositions,
+    walletCrossReservePositions,
     reserveSymbolById,
   ]);
 
@@ -365,9 +370,10 @@ export const useRateSimulation = ({
   borrowInput,
   inputMode = 'token',
   meritMerklNetPosition = true,
-  crossReservePositions,
-  reserveSymbolById,
-}: UseRateSimulationParams): RateSimulationResult => {
+    crossReservePositions,
+    walletCrossReservePositions,
+    reserveSymbolById,
+  }: UseRateSimulationParams): RateSimulationResult => {
   const reserveId = getReserveSimulationId(reserve);
   const { simulationsById } = useSharedRateSimulations({
     reserves: [reserve],
@@ -381,6 +387,7 @@ export const useRateSimulation = ({
     inputMode,
     meritMerklNetPosition,
     crossReservePositions,
+    walletCrossReservePositions,
     reserveSymbolById,
   });
 

--- a/src/lib/portfolioSimulator.test.ts
+++ b/src/lib/portfolioSimulator.test.ts
@@ -93,6 +93,8 @@ describe('buildPerReserveInputsFromEntries', () => {
       inputMode: 'usd',
       totalSupplyUsd: 1000,
       totalBorrowUsd: 500,
+      walletSupplyUsd: undefined,
+      walletBorrowUsd: undefined,
     });
     expect(result.perReserveInputs.get('r-weth')).toEqual({
       supplyInput: '2000',
@@ -100,6 +102,8 @@ describe('buildPerReserveInputsFromEntries', () => {
       inputMode: 'usd',
       totalSupplyUsd: 2000,
       totalBorrowUsd: 0,
+      walletSupplyUsd: undefined,
+      walletBorrowUsd: undefined,
     });
     expect(result.crossReservePositions).toBeDefined();
     expect(result.crossReservePositions!.get('r-usdc')).toEqual({ supplyUsd: 1000, borrowUsd: 500 });
@@ -140,7 +144,7 @@ describe('buildPerReserveInputsFromEntries', () => {
     ];
     const reserves = [makeRateCalcReserve({ reserveId: 'r-usdc' })];
     const result = buildPerReserveInputsFromEntries(entries, reserves);
-    expect(result.perReserveInputs.get('r-usdc')).toEqual({ supplyInput: '3000', borrowInput: '0', inputMode: 'usd', totalSupplyUsd: 3000, totalBorrowUsd: 0 });
+    expect(result.perReserveInputs.get('r-usdc')).toEqual({ supplyInput: '3000', borrowInput: '0', inputMode: 'usd', totalSupplyUsd: 3000, totalBorrowUsd: 0, walletSupplyUsd: undefined, walletBorrowUsd: undefined });
   });
 
   it('defaults supplyInput to "0" when only borrow exists', () => {
@@ -149,7 +153,7 @@ describe('buildPerReserveInputsFromEntries', () => {
     ];
     const reserves = [makeRateCalcReserve({ reserveId: 'r-usdc' })];
     const result = buildPerReserveInputsFromEntries(entries, reserves);
-    expect(result.perReserveInputs.get('r-usdc')).toEqual({ supplyInput: '0', borrowInput: '2000', inputMode: 'usd', totalSupplyUsd: 0, totalBorrowUsd: 2000 });
+    expect(result.perReserveInputs.get('r-usdc')).toEqual({ supplyInput: '0', borrowInput: '2000', inputMode: 'usd', totalSupplyUsd: 0, totalBorrowUsd: 2000, walletSupplyUsd: undefined, walletBorrowUsd: undefined });
   });
 
   it('resolves token amount to USD using tokenPrice', () => {
@@ -158,7 +162,7 @@ describe('buildPerReserveInputsFromEntries', () => {
     ];
     const reserves = [makeRateCalcReserve({ reserveId: 'r-weth', tokenSymbol: 'WETH', tokenPrice: 3000 })];
     const result = buildPerReserveInputsFromEntries(entries, reserves);
-    expect(result.perReserveInputs.get('r-weth')).toEqual({ supplyInput: '6000', borrowInput: '0', inputMode: 'usd', totalSupplyUsd: 6000, totalBorrowUsd: 0 });
+    expect(result.perReserveInputs.get('r-weth')).toEqual({ supplyInput: '6000', borrowInput: '0', inputMode: 'usd', totalSupplyUsd: 6000, totalBorrowUsd: 0, walletSupplyUsd: undefined, walletBorrowUsd: undefined });
   });
 
   it('ignores hidden entries', () => {
@@ -264,6 +268,7 @@ describe('buildPerReserveInputsFromEntries', () => {
     const input = result.perReserveInputs.get(reserveId)!;
     expect(input.supplyInput).toBe('0');
     expect(input.totalSupplyUsd).toBe(1042);
+    expect(input.walletSupplyUsd).toBe(1042);
     expect(result.crossReservePositions).toBeDefined();
     expect(result.crossReservePositions!.get(reserveId)).toEqual({ supplyUsd: 1042, borrowUsd: 0 });
     expect(result.reserveSymbolById).toBeDefined();
@@ -280,8 +285,10 @@ describe('buildPerReserveInputsFromEntries', () => {
     const input = result.perReserveInputs.get(reserveId)!;
     expect(input.supplyInput).toBe('0');
     expect(input.totalSupplyUsd).toBe(1042);
+    expect(input.walletSupplyUsd).toBe(1042);
     expect(input.borrowInput).toBe('1');
     expect(input.totalBorrowUsd).toBe(1);
+    expect(input.walletBorrowUsd).toBeUndefined();
     expect(result.crossReservePositions).toBeDefined();
     expect(result.crossReservePositions!.get(reserveId)).toEqual({ supplyUsd: 1042, borrowUsd: 1 });
     expect(result.reserveSymbolById).toBeDefined();
@@ -298,6 +305,7 @@ describe('buildPerReserveInputsFromEntries', () => {
     const input = result.perReserveInputs.get(reserveId)!;
     expect(input.supplyInput).toBe('0');
     expect(input.totalSupplyUsd).toBe(1000);
+    expect(input.walletSupplyUsd).toBe(1000);
     expect(result.crossReservePositions).toBeDefined();
     expect(result.crossReservePositions!.get(reserveId)).toEqual({ supplyUsd: 1000, borrowUsd: 0 });
     expect(result.reserveSymbolById).toBeDefined();
@@ -314,6 +322,7 @@ describe('buildPerReserveInputsFromEntries', () => {
     const input = result.perReserveInputs.get(reserveId)!;
     expect(input.supplyInput).toBe('500');
     expect(input.totalSupplyUsd).toBe(1500);
+    expect(input.walletSupplyUsd).toBe(1000);
     expect(result.crossReservePositions).toBeDefined();
     expect(result.crossReservePositions!.get(reserveId)).toEqual({ supplyUsd: 1500, borrowUsd: 0 });
     expect(result.reserveSymbolById).toBeDefined();
@@ -330,6 +339,7 @@ describe('buildPerReserveInputsFromEntries', () => {
     const input = result.perReserveInputs.get(reserveId)!;
     expect(input.supplyInput).toBe('-500');
     expect(input.totalSupplyUsd).toBe(500);
+    expect(input.walletSupplyUsd).toBe(1000);
     expect(result.crossReservePositions).toBeDefined();
     expect(result.crossReservePositions!.get(reserveId)).toEqual({ supplyUsd: 500, borrowUsd: 0 });
     expect(result.reserveSymbolById).toBeDefined();
@@ -346,6 +356,7 @@ describe('buildPerReserveInputsFromEntries', () => {
     const input = result.perReserveInputs.get(reserveId)!;
     expect(input.supplyInput).toBe('2000');
     expect(input.totalSupplyUsd).toBe(2000);
+    expect(input.walletSupplyUsd).toBeUndefined();
     expect(result.crossReservePositions).toBeDefined();
     expect(result.crossReservePositions!.get(reserveId)).toEqual({ supplyUsd: 2000, borrowUsd: 0 });
   });
@@ -361,6 +372,7 @@ describe('buildPerReserveInputsFromEntries', () => {
     const input = result.perReserveInputs.get(reserveId)!;
     expect(input.supplyInput).toBe('1000');
     expect(input.totalSupplyUsd).toBe(2000);
+    expect(input.walletSupplyUsd).toBe(1000);
     expect(result.crossReservePositions).toBeDefined();
     expect(result.crossReservePositions!.get(reserveId)).toEqual({ supplyUsd: 2000, borrowUsd: 0 });
   });
@@ -375,6 +387,7 @@ describe('buildPerReserveInputsFromEntries', () => {
     const input = result.perReserveInputs.get(reserveId)!;
     expect(input.borrowInput).toBe('300');
     expect(input.totalBorrowUsd).toBe(800);
+    expect(input.walletBorrowUsd).toBe(500);
     expect(result.crossReservePositions).toBeDefined();
     expect(result.crossReservePositions!.get(reserveId)).toEqual({ supplyUsd: 0, borrowUsd: 800 });
   });

--- a/src/lib/portfolioSimulator.ts
+++ b/src/lib/portfolioSimulator.ts
@@ -37,6 +37,7 @@ export interface PerReserveInput {
 export interface PortfolioInputsResult {
   perReserveInputs: Map<string, PerReserveInput>;
   crossReservePositions: Map<string, ReservePositions> | undefined;
+  walletCrossReservePositions: Map<string, ReservePositions> | undefined;
   reserveSymbolById: Map<string, string> | undefined;
 }
 
@@ -187,6 +188,7 @@ function computeResultsFromGroups(
   const results: PortfolioPositionResult[] = [];
 
   const crossReservePositions = new Map<string, ReservePositions>();
+  const walletCrossReservePositions = new Map<string, ReservePositions>();
   const reserveSymbolById = new Map<string, string>();
   for (const [key, group] of groupMap) {
     const reserve = reserveMap.get(key);
@@ -195,6 +197,12 @@ function computeResultsFromGroups(
       crossReservePositions.set(reserve.reserveId, {
         supplyUsd: group.supplyUsd,
         borrowUsd: group.borrowUsd,
+      });
+    }
+    if (group.walletSupplyUsd != null || group.walletBorrowUsd != null) {
+      walletCrossReservePositions.set(reserve.reserveId, {
+        supplyUsd: group.walletSupplyUsd ?? 0,
+        borrowUsd: group.walletBorrowUsd ?? 0,
       });
     }
     // Sets symbol for all reserves in groupMap (including those with 0 USD on both sides,
@@ -242,6 +250,7 @@ function computeResultsFromGroups(
         walletBorrowUsd: group.walletBorrowUsd,
         forecastStates,
         crossReservePositions,
+        walletCrossReservePositions: walletCrossReservePositions.size > 0 ? walletCrossReservePositions : undefined,
         reserveSymbolById,
         hubSupplied,
         hubBorrowed,
@@ -436,6 +445,7 @@ export function buildPerReserveInputsFromEntries(
 
   const perReserveInputs = new Map<string, PerReserveInput>();
   const crossReservePositions = new Map<string, ReservePositions>();
+  const walletCrossReservePositions = new Map<string, ReservePositions>();
   const reserveSymbolById = new Map<string, string>();
 
   for (const [reserveId, group] of grouped) {
@@ -453,6 +463,14 @@ export function buildPerReserveInputsFromEntries(
         supplyUsd: group.supplyUsd,
         borrowUsd: group.borrowUsd,
       });
+    }
+    if (group.walletSupplyUsd != null || group.walletBorrowUsd != null) {
+      walletCrossReservePositions.set(reserveId, {
+        supplyUsd: group.walletSupplyUsd ?? 0,
+        borrowUsd: group.walletBorrowUsd ?? 0,
+      });
+    }
+    if (group.supplyUsd > 0 || group.borrowUsd > 0) {
       const reserve = reserveMap.get(getReserveKey({ reserveId }));
       if (reserve?.tokenSymbol) {
         reserveSymbolById.set(reserveId, reserve.tokenSymbol);
@@ -463,6 +481,7 @@ export function buildPerReserveInputsFromEntries(
   return {
     perReserveInputs,
     crossReservePositions: crossReservePositions.size > 0 ? crossReservePositions : undefined,
+    walletCrossReservePositions: walletCrossReservePositions.size > 0 ? walletCrossReservePositions : undefined,
     reserveSymbolById: reserveSymbolById.size > 0 ? reserveSymbolById : undefined,
   };
 }

--- a/src/lib/portfolioSimulator.ts
+++ b/src/lib/portfolioSimulator.ts
@@ -28,6 +28,10 @@ export interface PerReserveInput {
   inputMode: ScenarioInputMode;
   totalSupplyUsd?: number;
   totalBorrowUsd?: number;
+  /** Wallet-only supply position (excludes manual delta). undefined when no wallet position exists. */
+  walletSupplyUsd?: number;
+  /** Wallet-only borrow position (excludes manual delta). undefined when no wallet position exists. */
+  walletBorrowUsd?: number;
 }
 
 export interface PortfolioInputsResult {
@@ -65,6 +69,8 @@ interface EntryGroup {
   borrowUsd: number;
   supplyDeltaUsd: number;
   borrowDeltaUsd: number;
+  walletSupplyUsd: number | undefined;
+  walletBorrowUsd: number | undefined;
 }
 
 export function buildMetricsFromLane(
@@ -147,16 +153,24 @@ function buildGroupMapFromSlots(
       borrowUsd: 0,
       supplyDeltaUsd: 0,
       borrowDeltaUsd: 0,
+      walletSupplyUsd: undefined,
+      walletBorrowUsd: undefined,
     };
 
     if (side === 'supply') {
       existing.supplySlots.push(slot);
       existing.supplyUsd += effectiveAmountUsd;
       existing.supplyDeltaUsd += deltaUsd;
+      if (hasWalletPosition) {
+        existing.walletSupplyUsd = (existing.walletSupplyUsd ?? 0) + s.walletValue!;
+      }
     } else {
       existing.borrowSlots.push(slot);
       existing.borrowUsd += effectiveAmountUsd;
       existing.borrowDeltaUsd += deltaUsd;
+      if (hasWalletPosition) {
+        existing.walletBorrowUsd = (existing.walletBorrowUsd ?? 0) + s.walletValue!;
+      }
     }
     groupMap.set(key, existing);
   }
@@ -224,6 +238,8 @@ function computeResultsFromGroups(
         inputMode: 'usd',
         totalSupplyUsd: group.supplyUsd,
         totalBorrowUsd: group.borrowUsd,
+        walletSupplyUsd: group.walletSupplyUsd,
+        walletBorrowUsd: group.walletBorrowUsd,
         forecastStates,
         crossReservePositions,
         reserveSymbolById,
@@ -359,7 +375,14 @@ export function buildPerReserveInputsFromEntries(
   const reserveMap = new Map(reserves.map((r) => [getReserveKey(r), r]));
   const grouped = new Map<
     string,
-    { supplyUsd: number; borrowUsd: number; supplyDeltaUsd: number; borrowDeltaUsd: number }
+    {
+      supplyUsd: number;
+      borrowUsd: number;
+      supplyDeltaUsd: number;
+      borrowDeltaUsd: number;
+      walletSupplyUsd: number | undefined;
+      walletBorrowUsd: number | undefined;
+    }
   >();
 
   for (const entry of entries) {
@@ -391,13 +414,21 @@ export function buildPerReserveInputsFromEntries(
         borrowUsd: 0,
         supplyDeltaUsd: 0,
         borrowDeltaUsd: 0,
+        walletSupplyUsd: undefined,
+        walletBorrowUsd: undefined,
       };
       if (side === 'supply') {
         existing.supplyUsd += effectiveAmountUsd;
         existing.supplyDeltaUsd += deltaUsd;
+        if (hasWalletPosition) {
+          existing.walletSupplyUsd = (existing.walletSupplyUsd ?? 0) + s.walletValue!;
+        }
       } else {
         existing.borrowUsd += effectiveAmountUsd;
         existing.borrowDeltaUsd += deltaUsd;
+        if (hasWalletPosition) {
+          existing.walletBorrowUsd = (existing.walletBorrowUsd ?? 0) + s.walletValue!;
+        }
       }
       grouped.set(entry.reserveId, existing);
     }
@@ -414,6 +445,8 @@ export function buildPerReserveInputsFromEntries(
       inputMode: 'usd',
       totalSupplyUsd: group.supplyUsd,
       totalBorrowUsd: group.borrowUsd,
+      walletSupplyUsd: group.walletSupplyUsd,
+      walletBorrowUsd: group.walletBorrowUsd,
     });
     if (group.supplyUsd > 0 || group.borrowUsd > 0) {
       crossReservePositions.set(reserveId, {

--- a/src/lib/rateSimulationCalculator.live.test.ts
+++ b/src/lib/rateSimulationCalculator.live.test.ts
@@ -302,6 +302,8 @@ describe.skipIf(!process.env.RUN_LIVE_TESTS)('Live API: incentive consistency on
           inputMode: 'usd',
           totalSupplyUsd: walletSupply,
           totalBorrowUsd: walletBorrow,
+          walletSupplyUsd: walletSupply,
+          walletBorrowUsd: walletBorrow,
         });
 
         // With supply delta
@@ -314,6 +316,8 @@ describe.skipIf(!process.env.RUN_LIVE_TESTS)('Live API: incentive consistency on
           inputMode: 'usd',
           totalSupplyUsd: walletSupply + 2000,
           totalBorrowUsd: walletBorrow,
+          walletSupplyUsd: walletSupply,
+          walletBorrowUsd: walletBorrow,
         });
 
         // With borrow delta
@@ -326,6 +330,8 @@ describe.skipIf(!process.env.RUN_LIVE_TESTS)('Live API: incentive consistency on
           inputMode: 'usd',
           totalSupplyUsd: walletSupply,
           totalBorrowUsd: walletBorrow + 2000,
+          walletSupplyUsd: walletSupply,
+          walletBorrowUsd: walletBorrow,
         });
 
         // currentIncentive must be identical — wallet hasn't changed
@@ -380,6 +386,8 @@ describe.skipIf(!process.env.RUN_LIVE_TESTS)('Live API: incentive consistency on
           inputMode: 'usd',
           totalSupplyUsd: walletSupply,
           totalBorrowUsd: walletBorrow + smallDelta,
+          walletSupplyUsd: walletSupply,
+          walletBorrowUsd: walletBorrow,
         });
 
         // Large delta (may exceed cap)
@@ -393,11 +401,12 @@ describe.skipIf(!process.env.RUN_LIVE_TESTS)('Live API: incentive consistency on
           inputMode: 'usd',
           totalSupplyUsd: walletSupply,
           totalBorrowUsd: walletBorrow + largeDelta,
+          walletSupplyUsd: walletSupply,
+          walletBorrowUsd: walletBorrow,
         });
 
         // currentIncentive must be the same — wallet borrow is $30000 in both cases
-        // With AAV-1120 fix: walletBorrowUsd = totalBorrowUsd - rawBorrowInputUsd
-        // Both give walletBorrowUsd = $30000 regardless of capping
+        // walletBorrowUsd is passed explicitly, so no derivation/capping ambiguity
         expect(rLarge.borrow.currentIncentive).toBeCloseTo(
           rSmall.borrow.currentIncentive,
           6,

--- a/src/lib/rateSimulationCalculator.test.ts
+++ b/src/lib/rateSimulationCalculator.test.ts
@@ -1658,6 +1658,9 @@ describe('AAV-1060: Merkl wallet position in net position constraint', () => {
     const crossReservePositions = new Map([
       [USDE_RESERVE_ID, { supplyUsd: 0, borrowUsd: 600 }],
     ]);
+    const walletCrossReservePositions = new Map([
+      [USDE_RESERVE_ID, { supplyUsd: 0, borrowUsd: 600 }],
+    ]);
 
     const result = buildRateSimulationResult({
       reserve: MERKL_CONSTRAINT_RESERVE,
@@ -1674,6 +1677,7 @@ describe('AAV-1060: Merkl wallet position in net position constraint', () => {
       totalBorrowUsd: 1,
       walletSupplyUsd: 1042,
       crossReservePositions,
+      walletCrossReservePositions,
     });
 
     const perSourceMerklCurrent = result.supply.sources.merkl?.current ?? 0;
@@ -1715,6 +1719,9 @@ describe('AAV-1060: Merkl wallet position in net position constraint', () => {
     const crossReservePositions = new Map([
       [USDE_RESERVE_ID, { supplyUsd: 0, borrowUsd: 600 }],
     ]);
+    const walletCrossReservePositions = new Map([
+      [USDE_RESERVE_ID, { supplyUsd: 0, borrowUsd: 600 }],
+    ]);
 
     const result = buildRateSimulationResult({
       reserve: MERKL_CONSTRAINT_RESERVE,
@@ -1731,6 +1738,7 @@ describe('AAV-1060: Merkl wallet position in net position constraint', () => {
       totalBorrowUsd: 1,
       walletSupplyUsd: 1042,
       crossReservePositions,
+      walletCrossReservePositions,
     });
 
     const merklCurrent = result.supply.sources.merkl?.current ?? 0;
@@ -1742,6 +1750,9 @@ describe('AAV-1060: Merkl wallet position in net position constraint', () => {
 
   it('headline incentive also includes eligibility scaling (AAV-1060 review fix)', () => {
     const crossReservePositions = new Map([
+      [USDE_RESERVE_ID, { supplyUsd: 0, borrowUsd: 600 }],
+    ]);
+    const walletCrossReservePositions = new Map([
       [USDE_RESERVE_ID, { supplyUsd: 0, borrowUsd: 600 }],
     ]);
 
@@ -1760,6 +1771,7 @@ describe('AAV-1060: Merkl wallet position in net position constraint', () => {
       totalBorrowUsd: 1,
       walletSupplyUsd: 1042,
       crossReservePositions,
+      walletCrossReservePositions,
     });
 
     const noConstraint: ReserveWithSpread = {
@@ -2661,5 +2673,173 @@ describe('AAV-1120: walletBorrowUsd/walletSupplyUsd derivation must use raw (unc
     // Both scenarios have the same wallet (supply=8000, borrow=5000).
     // currentIncentive must be the same.
     expect(rB.supply.currentIncentive).toBeCloseTo(rA.supply.currentIncentive, 6);
+  });
+});
+
+describe('AAV-1137: walletCrossReservePositions uses wallet-only for all reserves, not just self', () => {
+  const OFFSET_RESERVE_ID = '1:0xusde:0xusde';
+
+  const RESERVE_WITH_CROSS_CONSTRAINT: ReserveWithSpread = {
+    ...BASE_RESERVE,
+    supplyIncentives: [],
+    borrowIncentives: [],
+    meritSupplys: [],
+    meritBorrows: [],
+    merklSupplys: [
+      {
+        name: 'Cross-reserve net lending',
+        breakdowns: [
+          {
+            campaignApr: 10,
+            campaignStartedAt: '2020-01-01T00:00:00.000Z',
+            campaignEndedAt: '2099-01-01T00:00:00.000Z',
+            campaignId: 'aav-1137-test',
+          },
+        ],
+        opportunityId: '1137',
+        netPositionConstraint: {
+          sourceSide: 'supply',
+          offsetReserveIds: [OFFSET_RESERVE_ID],
+        },
+      },
+    ],
+    merklBorrows: [],
+  };
+
+  it('current does NOT change when offset reserve delta changes (walletCrossReservePositions uses wallet-only)', () => {
+    const walletCrossReservePositions = new Map([
+      [OFFSET_RESERVE_ID, { supplyUsd: 0, borrowUsd: 500 }],
+    ]);
+
+    const crpSmallDelta = new Map([
+      [OFFSET_RESERVE_ID, { supplyUsd: 0, borrowUsd: 500 }],
+    ]);
+    const crpLargeDelta = new Map([
+      [OFFSET_RESERVE_ID, { supplyUsd: 0, borrowUsd: 800 }],
+    ]);
+
+    const r1 = buildRateSimulationResult({
+      reserve: RESERVE_WITH_CROSS_CONSTRAINT,
+      reserveRateInput: VALID_RATE_INPUT,
+      isApy: false,
+      whitelistMerklCampaignIds: undefined,
+      tydroPointToUsdRate: 1,
+      tokenPrice: 1,
+      supplyInput: '0',
+      borrowInput: '0',
+      forecastStates: {},
+      meritMerklNetPosition: true,
+      totalSupplyUsd: 1000,
+      totalBorrowUsd: 0,
+      walletSupplyUsd: 1000,
+      walletBorrowUsd: 0,
+      crossReservePositions: crpSmallDelta,
+      walletCrossReservePositions,
+    });
+
+    const r2 = buildRateSimulationResult({
+      reserve: RESERVE_WITH_CROSS_CONSTRAINT,
+      reserveRateInput: VALID_RATE_INPUT,
+      isApy: false,
+      whitelistMerklCampaignIds: undefined,
+      tydroPointToUsdRate: 1,
+      tokenPrice: 1,
+      supplyInput: '0',
+      borrowInput: '0',
+      forecastStates: {},
+      meritMerklNetPosition: true,
+      totalSupplyUsd: 1000,
+      totalBorrowUsd: 0,
+      walletSupplyUsd: 1000,
+      walletBorrowUsd: 0,
+      crossReservePositions: crpLargeDelta,
+      walletCrossReservePositions,
+    });
+
+    expect(r1.supply.currentIncentive).toBeCloseTo(r2.supply.currentIncentive, 6);
+
+    const walletBorrow = 500;
+    const walletSupply = 1000;
+    const expectedNetEligible = Math.max(walletSupply - walletBorrow, 0);
+    const expectedRatio = expectedNetEligible / walletSupply;
+    const expectedCurrent = 10 * expectedRatio;
+    expect(r1.supply.currentIncentive).toBeCloseTo(expectedCurrent, 1);
+  });
+
+  it('after DOES change when offset reserve delta changes (uses crossReservePositions with total)', () => {
+    const walletCrossReservePositions = new Map([
+      [OFFSET_RESERVE_ID, { supplyUsd: 0, borrowUsd: 500 }],
+    ]);
+
+    const crpSmallDelta = new Map([
+      [OFFSET_RESERVE_ID, { supplyUsd: 0, borrowUsd: 500 }],
+    ]);
+    const crpLargeDelta = new Map([
+      [OFFSET_RESERVE_ID, { supplyUsd: 0, borrowUsd: 800 }],
+    ]);
+
+    const r1 = buildRateSimulationResult({
+      reserve: RESERVE_WITH_CROSS_CONSTRAINT,
+      reserveRateInput: VALID_RATE_INPUT,
+      isApy: false,
+      whitelistMerklCampaignIds: undefined,
+      tydroPointToUsdRate: 1,
+      tokenPrice: 1,
+      supplyInput: '500',
+      borrowInput: '0',
+      inputMode: 'usd',
+      forecastStates: {},
+      meritMerklNetPosition: true,
+      totalSupplyUsd: 1500,
+      totalBorrowUsd: 0,
+      walletSupplyUsd: 1000,
+      walletBorrowUsd: 0,
+      crossReservePositions: crpSmallDelta,
+      walletCrossReservePositions,
+    });
+
+    const r2 = buildRateSimulationResult({
+      reserve: RESERVE_WITH_CROSS_CONSTRAINT,
+      reserveRateInput: VALID_RATE_INPUT,
+      isApy: false,
+      whitelistMerklCampaignIds: undefined,
+      tydroPointToUsdRate: 1,
+      tokenPrice: 1,
+      supplyInput: '500',
+      borrowInput: '0',
+      inputMode: 'usd',
+      forecastStates: {},
+      meritMerklNetPosition: true,
+      totalSupplyUsd: 1500,
+      totalBorrowUsd: 0,
+      walletSupplyUsd: 1000,
+      walletBorrowUsd: 0,
+      crossReservePositions: crpLargeDelta,
+      walletCrossReservePositions,
+    });
+
+    expect(r1.supply.afterIncentive).not.toBeCloseTo(r2.supply.afterIncentive, 1);
+  });
+
+  it('without walletCrossReservePositions, current=headline (no scaling) — GOLDEN RULE no-wallet case', () => {
+    const crossReservePositions = new Map([
+      [OFFSET_RESERVE_ID, { supplyUsd: 0, borrowUsd: 600 }],
+    ]);
+
+    const result = buildRateSimulationResult({
+      reserve: RESERVE_WITH_CROSS_CONSTRAINT,
+      reserveRateInput: VALID_RATE_INPUT,
+      isApy: false,
+      whitelistMerklCampaignIds: undefined,
+      tydroPointToUsdRate: 1,
+      tokenPrice: 1,
+      supplyInput: '1000',
+      borrowInput: '0',
+      forecastStates: {},
+      meritMerklNetPosition: true,
+      crossReservePositions,
+    });
+
+    expect(result.supply.currentIncentive).toBeCloseTo(10.0, 1);
   });
 });

--- a/src/lib/rateSimulationCalculator.test.ts
+++ b/src/lib/rateSimulationCalculator.test.ts
@@ -931,21 +931,10 @@ describe('deltaIncentive shows dilution gap when hasInput=false but wallet exist
     expect(result.supply.afterIncentive).not.toBeNull();
   });
 
-  it('derives wallet correctly when both totalSupplyUsd and supplyInputUsd are present', () => {
+  it('uses explicit walletSupplyUsd for position cap dilution', () => {
     // totalSupplyUsd = wallet(1500) + delta(500) = 2000
-    // walletSupplyUsd should be derived as 2000 - 500 = 1500
+    // walletSupplyUsd = 1500 > cap = 1000 → currentIncentive is diluted
     const result = buildRateSimulationResult({
-      reserve: MERIT_POSITION_CAP_RESERVE,
-      reserveRateInput: VALID_RATE_INPUT,
-      ...BASE_PARAMS,
-      supplyInput: '500',
-      totalSupplyUsd: 2000,
-      // No walletSupplyUsd passed explicitly
-    });
-
-    expect(result.supply.hasInput).toBe(true);
-    // Wallet derivation should match explicit walletSupplyUsd=1500 result
-    const withExplicitWallet = buildRateSimulationResult({
       reserve: MERIT_POSITION_CAP_RESERVE,
       reserveRateInput: VALID_RATE_INPUT,
       ...BASE_PARAMS,
@@ -954,7 +943,10 @@ describe('deltaIncentive shows dilution gap when hasInput=false but wallet exist
       walletSupplyUsd: 1500,
     });
 
-    expect(result.supply.currentIncentive).toBeCloseTo(withExplicitWallet.supply.currentIncentive, 6);
+    expect(result.supply.hasInput).toBe(true);
+    // Wallet = 1500 > cap = 1000 → dilution = 1000/1500 ≈ 0.667
+    // self-cap current = 8 * 0.667 ≈ 5.33, total current = 10 + 5.33 = 15.33
+    expect(result.supply.currentIncentive).toBeCloseTo(15.333333, 1);
   });
 });
 
@@ -1680,6 +1672,7 @@ describe('AAV-1060: Merkl wallet position in net position constraint', () => {
       meritMerklNetPosition: true,
       totalSupplyUsd: 1042,
       totalBorrowUsd: 1,
+      walletSupplyUsd: 1042,
       crossReservePositions,
     });
 
@@ -1736,6 +1729,7 @@ describe('AAV-1060: Merkl wallet position in net position constraint', () => {
       meritMerklNetPosition: true,
       totalSupplyUsd: 1042,
       totalBorrowUsd: 1,
+      walletSupplyUsd: 1042,
       crossReservePositions,
     });
 
@@ -1764,6 +1758,7 @@ describe('AAV-1060: Merkl wallet position in net position constraint', () => {
       meritMerklNetPosition: true,
       totalSupplyUsd: 1042,
       totalBorrowUsd: 1,
+      walletSupplyUsd: 1042,
       crossReservePositions,
     });
 
@@ -1794,6 +1789,7 @@ describe('AAV-1060: Merkl wallet position in net position constraint', () => {
       meritMerklNetPosition: true,
       totalSupplyUsd: 1042,
       totalBorrowUsd: 1,
+      walletSupplyUsd: 1042,
     });
 
     expect(withConstraint.supply.currentIncentive).toBeLessThan(withoutConstraint.supply.currentIncentive);
@@ -1862,6 +1858,8 @@ describe('AAV-1102: Merit per-campaign current uses walletEligibilityRatio', () 
       meritMerklNetPosition: true,
       totalSupplyUsd: 1000,
       totalBorrowUsd: 400,
+      walletSupplyUsd: 1000,
+      walletBorrowUsd: 400,
     });
 
     const meritCampaigns = result.supply.sources.merit?.campaigns ?? [];
@@ -1886,6 +1884,8 @@ describe('AAV-1102: Merit per-campaign current uses walletEligibilityRatio', () 
       meritMerklNetPosition: true,
       totalSupplyUsd: 1000,
       totalBorrowUsd: 400,
+      walletSupplyUsd: 1000,
+      walletBorrowUsd: 400,
     });
 
     const meritCampaigns = result.supply.sources.merit?.campaigns ?? [];
@@ -2004,6 +2004,7 @@ describe('AAV-1102: Brevis per-campaign current applies wallet position cap dilu
       borrowInput: '0',
       forecastStates: {},
       totalSupplyUsd: 10000,
+      walletSupplyUsd: 10000,
     });
 
     const brevisCampaigns = result.supply.sources.brevis?.campaigns ?? [];
@@ -2028,6 +2029,7 @@ describe('AAV-1102: Brevis per-campaign current applies wallet position cap dilu
       borrowInput: '0',
       forecastStates: {},
       totalSupplyUsd: 3000,
+      walletSupplyUsd: 3000,
     });
 
     const brevisCampaigns = result.supply.sources.brevis?.campaigns ?? [];
@@ -2049,6 +2051,7 @@ describe('AAV-1102: Brevis per-campaign current applies wallet position cap dilu
       borrowInput: '0',
       forecastStates: {},
       totalSupplyUsd: 10000,
+      walletSupplyUsd: 10000,
     });
 
     const brevisCampaigns = result.supply.sources.brevis?.campaigns ?? [];
@@ -2098,6 +2101,8 @@ describe('AAV-1102: aggregate sumCurrent matches buildIncentiveCurrent for all s
       meritMerklNetPosition: true,
       totalSupplyUsd: 2000,
       totalBorrowUsd: 500,
+      walletSupplyUsd: 2000,
+      walletBorrowUsd: 500,
     });
 
     const protocolCurrent = result.supply.sources.protocol?.current ?? 0;
@@ -2143,6 +2148,7 @@ describe('AAV-1107: aggregate currentIncentive matches per-source sum with Merkl
       meritMerklNetPosition: true,
       totalSupplyUsd: 5000,
       totalBorrowUsd: 0,
+      walletSupplyUsd: 5000,
     });
 
     const merklCurrent = result.supply.sources.merkl?.current ?? 0;
@@ -2172,6 +2178,7 @@ describe('AAV-1107: aggregate currentIncentive matches per-source sum with Merkl
       meritMerklNetPosition: true,
       totalSupplyUsd: 500,
       totalBorrowUsd: 0,
+      walletSupplyUsd: 500,
     });
 
     const merklCurrent = result.supply.sources.merkl?.current ?? 0;
@@ -2228,6 +2235,7 @@ describe('AAV-1112: currentIncentive derived from per-source sum (no independent
       meritMerklNetPosition: true,
       totalSupplyUsd: 5000, // exceeds Merkl cap → dilution
       totalBorrowUsd: 0,
+      walletSupplyUsd: 5000,
     });
 
     const p = result.supply.sources.protocol?.current ?? 0;
@@ -2266,6 +2274,7 @@ describe('AAV-1112: currentIncentive derived from per-source sum (no independent
       meritMerklNetPosition: true,
       totalBorrowUsd: 5000,
       totalSupplyUsd: 0,
+      walletBorrowUsd: 5000,
     });
 
     const p = result.borrow.sources.protocol?.current ?? 0;
@@ -2320,6 +2329,7 @@ describe('AAV-1113: afterIncentive derived from per-source sum (no independent p
       meritMerklNetPosition: true,
       totalSupplyUsd: 5000, // exceeds Merkl cap → dilution
       totalBorrowUsd: 0,
+      walletSupplyUsd: 4500, // wallet = 5000 - 500 delta
     });
 
     expect(result.supply.afterIncentive).not.toBeNull();
@@ -2346,6 +2356,7 @@ describe('AAV-1113: afterIncentive derived from per-source sum (no independent p
       meritMerklNetPosition: true,
       totalSupplyUsd: 5000,
       totalBorrowUsd: 0,
+      walletSupplyUsd: 4500,
     });
     const rWithBorrow = buildRateSimulationResult({
       reserve: ALL_SOURCES_RESERVE,
@@ -2360,6 +2371,8 @@ describe('AAV-1113: afterIncentive derived from per-source sum (no independent p
       meritMerklNetPosition: true,
       totalSupplyUsd: 5000,
       totalBorrowUsd: 2000,
+      walletSupplyUsd: 4500,
+      walletBorrowUsd: 2000,
     });
 
     expect(rNoBorrow.supply.afterIncentive).not.toBeNull();
@@ -2382,6 +2395,7 @@ describe('AAV-1113: afterIncentive derived from per-source sum (no independent p
       meritMerklNetPosition: true,
       totalSupplyUsd: 5000,
       totalBorrowUsd: 0,
+      walletSupplyUsd: 5000,
     });
 
     expect(result.supply.afterIncentive).toBeNull();

--- a/src/lib/rateSimulationCalculator.ts
+++ b/src/lib/rateSimulationCalculator.ts
@@ -262,8 +262,10 @@ export interface BuildRateSimulationResultParams {
    * When false, each side uses its full scenario USD independently. Brevis is always gross per side.
    */
   meritMerklNetPosition?: boolean;
-  /** Cross-reserve positions for merkl per-group net eligibility ratio computation. */
+  /** Cross-reserve positions (total = wallet + delta) for merkl per-group net eligibility ratio computation (after*). */
   crossReservePositions?: Map<string, ReservePositions>;
+  /** Cross-reserve wallet-only positions for current* and headline (AAV-1137). Must be undefined when no wallet. */
+  walletCrossReservePositions?: Map<string, ReservePositions>;
   /** reserveId b symbol lookup for cross-reserve note (offset reserve symbols). */
   reserveSymbolById?: Map<string, string>;
   campaignAccessStatuses?: Record<string, 'allowed' | 'whitelist-blocked' | 'blacklisted'>;
@@ -290,12 +292,14 @@ export interface BuildRateSimulationResultParams {
   totalBorrowUsd?: number;
   /**
    * Wallet-only supply position (USD) for position cap dilution in current incentive.
-   * If not provided, derived from totalSupplyUsd - supplyInputUsd.
+   * Passed explicitly by the caller from PerReserveInput.
+   * undefined when no wallet position exists (triggers identity fallback — Golden Rule §3).
    */
   walletSupplyUsd?: number;
   /**
    * Wallet-only borrow position (USD) for position cap dilution in current incentive.
-   * If not provided, derived from totalBorrowUsd - borrowInputUsd.
+   * Passed explicitly by the caller from PerReserveInput.
+   * undefined when no wallet position exists (triggers identity fallback — Golden Rule §3).
    */
   walletBorrowUsd?: number;
   /** Per-symbol point rate map for per-campaign rate routing (AAV-898). */
@@ -1011,6 +1015,7 @@ export function buildRateSimulationResult({
   forecastStates,
   meritMerklNetPosition = true,
   crossReservePositions,
+  walletCrossReservePositions,
   reserveSymbolById,
   campaignAccessStatuses,
   hubSupplied,
@@ -1191,13 +1196,8 @@ export function buildRateSimulationResult({
 
   // GOLDEN RULE (AAV-1121): walletCrossReservePositions must be undefined when no wallet.
   // This ensures walletMerklGroupMultiplier returns 1.0 (identity) for current*.
-  const walletCrossReservePositions = hasWallet && crossReservePositions ? new Map(crossReservePositions) : undefined;
-  if (walletCrossReservePositions && walletCrossReservePositions.has(reserve.reserveId)) {
-    walletCrossReservePositions.set(reserve.reserveId, {
-      supplyUsd: walletSupplyUsd ?? 0,
-      borrowUsd: walletBorrowUsd ?? 0,
-    });
-  }
+  // AAV-1137: Built by the caller from wallet-only positions across ALL reserves,
+  // not just the self-entry, so current* never changes with simulation input on other reserves.
 
   const merklGroupMultiplier = (side: RateSide): ((group: MerklOpportunityGroup) => number) => {
     const grossUsd = side === 'supply' ? supplyGrossForEligibility : borrowGrossForEligibility;

--- a/src/lib/rateSimulationCalculator.ts
+++ b/src/lib/rateSimulationCalculator.ts
@@ -1144,15 +1144,10 @@ export function buildRateSimulationResult({
   // user's simulation input. A wallet position above the cap should show diluted
   // incentive even when the user hasn't entered any delta.
   //
-  // AAV-1120: Must use RAW (uncapped) input for wallet derivation.
-  // totalBorrowUsd = wallet + rawDelta, so wallet = total - rawDelta.
-  // Using capped delta gives wallet = total - cappedDelta → wallet too large.
-  const walletSupplyUsd = explicitWalletSupplyUsd ?? (totalSupplyUsd != null
-    ? totalSupplyUsd - rawSupplyInputUsd
-    : undefined);
-  const walletBorrowUsd = explicitWalletBorrowUsd ?? (totalBorrowUsd != null
-    ? totalBorrowUsd - rawBorrowInputUsd
-    : undefined);
+  // Wallet positions are passed explicitly by the caller (from PerReserveInput).
+  // No reverse derivation — see AAV-1140 / docs/specs/wallet-position-explicit-passing.md.
+  const walletSupplyUsd = explicitWalletSupplyUsd;
+  const walletBorrowUsd = explicitWalletBorrowUsd;
 
   // AAV-1060: Eligibility ratio and merklGroupMultiplier must be computed before
   // buildIncentiveCurrent so that aggregate current matches per-source current.

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -46,6 +46,8 @@ import { externalLinkTabProps } from '@/lib/externalNavigation';
 
 import InkAprCalculator from '@/components/dashboard/InkAprCalculator';
 import FaqSection from '@/components/dashboard/FaqSection';
+import { Helmet } from 'react-helmet-async';
+import { SITE_ORIGIN } from '@/i18n';
 
 const Index = () => {
   const activeQueryCount = useIsFetching();
@@ -495,6 +497,9 @@ const Index = () => {
   // If we have cached data, use it; otherwise show empty state
   return (
     <PullToRefresh onRefresh={handleRefresh}>
+      <Helmet>
+        <link rel="canonical" href={`${SITE_ORIGIN}/`} />
+      </Helmet>
       <div className="min-h-screen min-w-0 w-full bg-background">
         {/* Background gradient */}
         <div className="fixed inset-0 bg-gradient-radial from-primary/5 via-transparent to-transparent pointer-events-none" />


### PR DESCRIPTION
## Summary
Sync lovable → dev with merge commit.

### Key Changes
- **fix**: add canonical link to Index page via Helmet
- **fix(AAV-1137)**: walletCrossReservePositions uses wallet-only for all reserves
- **refactor**: eliminate wallet position reverse derivation in calculator
- **chore**: fix stale JSDoc, add live simulation tests to CI, add .vercel to gitignore
- **docs**: AAV-1140 lesson