### PR TITLE
fix(lint): resolve reviewdog ESLint warnings from PR #408

### DIFF
--- a/src/components/dashboard/portfolioColumns.tsx
+++ b/src/components/dashboard/portfolioColumns.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable react-refresh/only-export-components -- constants + colgroup are tightly coupled */
+
 /**
  * Shared column geometry for Portfolio summary + results tables.
  *

--- a/src/pages/AdminSeo.tsx
+++ b/src/pages/AdminSeo.tsx
@@ -44,6 +44,8 @@ function fmtUsd(n: number | null | undefined) {
   return formatUsd(n);
 }
 
+const EMPTY_ROWS: never[] = [];
+
 const AdminSeoInner = ({ onSignOut }: { onSignOut: () => void }) => {
   const [preset, setPreset] = useState<RangePreset>("28d");
   const [selectedCountries, setSelectedCountries] = useState<Set<string>>(
@@ -84,7 +86,7 @@ const AdminSeoInner = ({ onSignOut }: { onSignOut: () => void }) => {
     });
   };
 
-  const gscRows = gscQuery.data?.rows ?? [];
+  const gscRows = gscQuery.data?.rows ?? EMPTY_ROWS;
   const semrushRows = semrushQuery.data?.rows ?? [];
 
   // Country-level GSC aggregates


### PR DESCRIPTION
## Summary

修复 PR #408 上的两个 reviewdog ESLint warning。

**修改内容：**

1. **portfolioColumns.tsx** — 添加文件级 `eslint-disable react-refresh/only-export-components`，常量与 `PortfolioColgroup` 组件有意共存
2. **AdminSeo.tsx** — 用模块级 `EMPTY_ROWS` 常量替代 `?? []`，避免 `useMemo` 依赖每次 render 变化（修复 `react-hooks/exhaustive-deps`）

Refs: #408