### PR TITLE
chore(deps): safe minor/patch upgrades (ws/js-yaml/shell-quote)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7698,10 +7698,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -9309,7 +9319,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10208,27 +10220,6 @@
       },
       "peerDependenciesMeta": {
         "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/viem/node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -142,10 +142,13 @@
     "zod": "^4.3.6"
   },
   "overrides": {
+    "@types/react": "$@types/react",
+    "@types/react-dom": "$@types/react-dom",
+    "js-yaml": "4.3.0",
     "react": "$react",
     "react-dom": "$react-dom",
-    "@types/react": "$@types/react",
-    "@types/react-dom": "$@types/react-dom"
+    "shell-quote": "1.9.0",
+    "ws": "8.21.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",


### PR DESCRIPTION
## Summary
Split from closed PR #411. Uses `package.json` `overrides` to force specific transitive-dependency versions across the entire dep tree.

### Packages upgraded
| Package | From | To | Type | Why |
|---|---|---|---|---|
| **ws** | 8.20.1 | 8.21.0 | patch | Fixes **GHSA-96hv-2xvq-fx4p** (memory exhaustion DoS) — also removes entry from `.github/npm-audit-exemptions.json` on next audit |
| **js-yaml** | 4.1.1 | 4.3.0 | minor | Regular maintenance (via eslint) |
| **shell-quote** | 1.8.3 | 1.9.0 | minor | Regular maintenance (via concurrently) |

### Not included
- **vite 7→8** (major)
- **vitest 3→4** (major)

These will ship in a separate PR after dedicated testing.

### Why overrides instead of `npm update`
All three packages are **transitive dependencies** (not in `package.json`). `npm update` alone can't force specific versions of transitive deps — `overrides` ensures the version is pinned everywhere.

## Test plan
- [x] Local validation gate: lint, test (3053 passed), build, tsc — all green
- [x] CI checks pass