### PR TITLE
fix: remediate simulation review findings (AAV-1171)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,7 +253,7 @@ jobs:
       needs.openapi-check.result == 'failure'
     runs-on: ubuntu-latest
     env:
-      LIVE_API_BASE: ${{ vars.LIVE_TEST_API_BASE_CI != '' && vars.LIVE_TEST_API_BASE_CI || 'https://staging-api.aaveapy.com/api' }}
+      LIVE_API_BASE: ${{ secrets.LIVE_TEST_API_BASE_CI || 'https://staging-api.aaveapy.com/api' }}
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/hardcode-sync.yml
+++ b/.github/workflows/hardcode-sync.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           echo "event_name=${{ github.event_name }}"
           echo "target_branch=${{ env.TARGET_BRANCH }}"
-          echo "live_test_api_base_ci_source=${{ vars.LIVE_TEST_API_BASE_CI != '' && 'repository_variable' || 'workflow_default_staging' }}"
+          echo "live_test_api_base_ci_source=${{ secrets.LIVE_TEST_API_BASE_CI != '' && 'repository_secret' || 'workflow_default_staging' }}"
           echo "repository_dispatch=${{ github.event_name == 'repository_dispatch' && 'true' || 'false' }}"
           if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
             echo "client_payload=${{ toJSON(github.event.client_payload) }}"
@@ -63,7 +63,7 @@ jobs:
       - name: Round 1 sync
         id: sync_round1
         env:
-          LIVE_TEST_API_BASE_CI: ${{ vars.LIVE_TEST_API_BASE_CI != '' && vars.LIVE_TEST_API_BASE_CI || 'https://staging-api.aaveapy.com/api' }}
+          LIVE_TEST_API_BASE_CI: ${{ secrets.LIVE_TEST_API_BASE_CI != '' && secrets.LIVE_TEST_API_BASE_CI || 'https://staging-api.aaveapy.com/api' }}
         run: |
           set +e
           npm run hardcode:sync
@@ -79,7 +79,7 @@ jobs:
       - name: Round 1 verify
         id: verify_round1
         env:
-          LIVE_TEST_API_BASE_CI: ${{ vars.LIVE_TEST_API_BASE_CI != '' && vars.LIVE_TEST_API_BASE_CI || 'https://staging-api.aaveapy.com/api' }}
+          LIVE_TEST_API_BASE_CI: ${{ secrets.LIVE_TEST_API_BASE_CI != '' && secrets.LIVE_TEST_API_BASE_CI || 'https://staging-api.aaveapy.com/api' }}
         run: |
           set +e
           npm run hardcode:verify
@@ -95,7 +95,7 @@ jobs:
         if: steps.verify_round1.outputs.passed != 'true'
         id: sync_round2
         env:
-          LIVE_TEST_API_BASE_CI: ${{ vars.LIVE_TEST_API_BASE_CI != '' && vars.LIVE_TEST_API_BASE_CI || 'https://staging-api.aaveapy.com/api' }}
+          LIVE_TEST_API_BASE_CI: ${{ secrets.LIVE_TEST_API_BASE_CI != '' && secrets.LIVE_TEST_API_BASE_CI || 'https://staging-api.aaveapy.com/api' }}
         run: |
           set +e
           npm run hardcode:sync
@@ -112,7 +112,7 @@ jobs:
         id: verify_round2
         if: steps.verify_round1.outputs.passed != 'true'
         env:
-          LIVE_TEST_API_BASE_CI: ${{ vars.LIVE_TEST_API_BASE_CI != '' && vars.LIVE_TEST_API_BASE_CI || 'https://staging-api.aaveapy.com/api' }}
+          LIVE_TEST_API_BASE_CI: ${{ secrets.LIVE_TEST_API_BASE_CI != '' && secrets.LIVE_TEST_API_BASE_CI || 'https://staging-api.aaveapy.com/api' }}
         run: |
           set +e
           npm run hardcode:verify

--- a/docs/conventions/ci-live-schema-cloudflare.md
+++ b/docs/conventions/ci-live-schema-cloudflare.md
@@ -125,4 +125,6 @@ curl -sS "https://staging-api.aaveapy.com/api/markets" | head -c 120
 
 4. 之后 `main` 分支上的 `live-schema-validation` / `live-simulation-validation` job 会优先使用这个 Secret（`secrets.LIVE_TEST_API_BASE_CI`）；未配置时仍回退到 `https://staging-api.aaveapy.com/api`
 
-> **Note**: 此值原为明文 GitHub Variable，已迁移为加密 Secret 以避免 Railway 内部域名暴露在 repo settings 明文中。CI workflow 引用已从 `vars.LIVE_TEST_API_BASE_CI` 改为 `secrets.LIVE_TEST_API_BASE_CI`。
+> **Note**: 此值原为明文 GitHub Variable，已迁移为加密 Secret 以避免 Railway 内部域名暴露在 repo settings 明文中。所有 workflow 引用已从 `vars.LIVE_TEST_API_BASE_CI` 改为 `secrets.LIVE_TEST_API_BASE_CI`。
+>
+> **Lesson (AAV-429)**: 迁移时必须同时更新所有引用该变量的 workflow 文件。本次漏改 `hardcode-sync.yml`（只改了 `ci.yml`），导致 `vars.` 返回空值、fallback 到 staging-api 被 Cloudflare 403 拦截，hardcode sync 连续失败。涉及 `LIVE_TEST_API_BASE_CI` 的 workflow：`ci.yml`、`hardcode-sync.yml`。

--- a/docs/lessons/infrastructure.md
+++ b/docs/lessons/infrastructure.md
@@ -27,3 +27,8 @@ Historical lessons from CI/CD, external API integration, and deployment. Extract
 - **`--no-merges` 过滤噪音**：`git log A..B --no-merges --oneline` 只显示实质 commit，去掉 merge commit 的虚高计数。
 - **`git cherry` 检测等价 patch**：`git cherry A B` 标记哪些 commit 的改动已在对面存在（`+` = 新增，`-` = 等价已存在），适合判断哪些 commit 真正需要合并。
 - **结论**：看到 ahead/behind 数字大时，先 `git diff --stat` 确认实际代码差异，再决定 pull/merge 策略，避免被 merge commit 历史误导。
+
+## GitHub Variable → Secret 迁移必须更新所有引用 workflow（AAV-429）
+- **迁移 GitHub Variable 到 Secret 时，必须 grep 所有 workflow 文件中的引用**：本次只改了 `ci.yml` 的 `vars.LIVE_TEST_API_BASE_CI` → `secrets.LIVE_TEST_API_BASE_CI`，漏改 `hardcode-sync.yml`，导致后者 fallback 到 staging-api 被 Cloudflare Bot Fight Mode 403 拦截，hardcode sync 连续失败。
+- **`vars.` 引用已删除的 Variable 返回空字符串**：GitHub 不会报错，而是静默返回空，触发 fallback 逻辑。如果 fallback 指向被 Cloudflare 保护的域名，CI 就会 403 但不给出明确原因。
+- **涉及 `LIVE_TEST_API_BASE_CI` 的 workflow**：`ci.yml`、`hardcode-sync.yml`。迁移时用 `grep -r 'vars\.LIVE_TEST_API_BASE_CI' .github/workflows/` 确认无遗漏。

--- a/e2e/reserves-table-simulation-full-after-scenario-pin.spec.ts
+++ b/e2e/reserves-table-simulation-full-after-scenario-pin.spec.ts
@@ -22,6 +22,89 @@ async function getPinnedTopY(page: Parameters<typeof test>[0]['page']): Promise<
   return maxBottom + 8;
 }
 
+async function getVisibleReserveOrder(
+  page: Parameters<typeof test>[0]['page'],
+): Promise<string[]> {
+  return page.locator('tbody tr[data-reserve-id]').evaluateAll((rows) =>
+    rows
+      .map((row) => row.getAttribute('data-reserve-id') ?? '')
+      .filter((id) => id.length > 0),
+  );
+}
+
+function didReorder(beforeOrder: string[], afterOrder: string[]): boolean {
+  return (
+    beforeOrder.length !== afterOrder.length ||
+    beforeOrder.some((id, index) => id !== afterOrder[index])
+  );
+}
+
+async function setScenarioInputs(
+  page: Parameters<typeof test>[0]['page'],
+  values: { supply: string; borrow: string },
+) {
+  await page.locator(
+    '[data-reserves-sticky-scenario] input[aria-label="Supply amount"]',
+  ).fill(values.supply);
+  await page.locator(
+    '[data-reserves-sticky-scenario] input[aria-label="Borrow amount"]',
+  ).fill(values.borrow);
+}
+
+async function installScrollByProbe(page: Parameters<typeof test>[0]['page']) {
+  await page.evaluate(() => {
+    type ProbedWindow = Window & {
+      __e2eScrollByCalls?: number;
+      __e2eOriginalScrollBy?: typeof window.scrollBy;
+    };
+    const win = window as ProbedWindow;
+    if (!win.__e2eOriginalScrollBy) {
+      win.__e2eOriginalScrollBy = window.scrollBy.bind(window);
+      window.scrollBy = ((...args: Parameters<typeof window.scrollBy>) => {
+        win.__e2eScrollByCalls = (win.__e2eScrollByCalls ?? 0) + 1;
+        win.__e2eOriginalScrollBy?.(...args);
+      }) as typeof window.scrollBy;
+    }
+    win.__e2eScrollByCalls = 0;
+  });
+}
+
+async function resetScrollByProbe(page: Parameters<typeof test>[0]['page']) {
+  await page.evaluate(() => {
+    type ProbedWindow = Window & { __e2eScrollByCalls?: number };
+    (window as ProbedWindow).__e2eScrollByCalls = 0;
+  });
+}
+
+async function getScrollByProbeCount(
+  page: Parameters<typeof test>[0]['page'],
+): Promise<number> {
+  return page.evaluate(() => {
+    type ProbedWindow = Window & { __e2eScrollByCalls?: number };
+    return (window as ProbedWindow).__e2eScrollByCalls ?? 0;
+  });
+}
+
+async function moveRowAwayFromPinBand(
+  page: Parameters<typeof test>[0]['page'],
+  reserveId: string,
+) {
+  const mainRow = page.locator(`tbody tr[data-reserve-id="${reserveId}"]`).first();
+  const pinnedTopY = await getPinnedTopY(page);
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    const box = await mainRow.boundingBox();
+    if (box && box.y - pinnedTopY >= 180) return;
+    const delta = box ? box.y - (pinnedTopY + 260) : -260;
+    await page.evaluate((top) => window.scrollBy({ top, behavior: 'auto' }), delta);
+    await page.waitForTimeout(120);
+  }
+  const box = await mainRow.boundingBox();
+  expect(
+    box ? box.y - pinnedTopY : 0,
+    'expanded row should be moved away from the pin band before the scenario change',
+  ).toBeGreaterThanOrEqual(180);
+}
+
 function simulationScrollPortForMainRow(mainRow: Locator) {
   return mainRow
     .locator('xpath=following-sibling::tr[1]')
@@ -29,49 +112,23 @@ function simulationScrollPortForMainRow(mainRow: Locator) {
     .first();
 }
 
-/**
- * Regression (desktop): after scenario-driven re-sort + pin, expanded simulation should not be
- * clipped by an inner `overflow-y` scrollport (`scrollHeight` should fit `clientHeight`).
- *
- * Today `DesktopReserveRow` uses `max-height` + `overflow-y-auto`, so the **last** expect fails until
- * layout is fixed.
- *
- * Flow matches `reserves-table-scenario-pin.spec.ts` through the first pin, then we assert on the
- * inner scrollport.
- *
- * **Why a temporary max-height clamp:** before layout settles, `mainRowHeight` can be 0 so React
- * omits `max-height` and `scrollHeight === clientHeight` (no measurable inner overflow). The same
- * E2E clamp pattern as `reserves-table-simulation-nested-scroll.spec.ts` forces a clipped pane so
- * the regression line (`scrollHeight` should fit `clientHeight` when the product shows the full
- * simulation) fails reliably until `DesktopReserveRow` stops capping the wrapper.
- */
 test.describe('Simulation fully visible after scenario-driven pin (desktop)', () => {
-  test.beforeEach(async ({ page: _page }, testInfo) => {
-    test.skip(
-      testInfo.project.name.includes('mobile'),
-      'Pin scroll + desktop expanded simulation only',
-    );
-  });
-
-  test('after re-sort and pin, simulation scrollport has no inner vertical overflow', async ({
+  test('after a scenario-driven pin, simulation has no inner vertical overflow', async ({
     page,
   }) => {
-    test.setTimeout(120_000);
+    test.setTimeout(180_000);
 
     await page.goto('/');
     await waitDesktopReservesReady(page);
-
-    const supplyInput = page.locator('[data-reserves-sticky-scenario] input[aria-label="Supply amount"]');
-    const borrowInput = page.locator('[data-reserves-sticky-scenario] input[aria-label="Borrow amount"]');
-
-    await supplyInput.fill('100');
+    await installScrollByProbe(page);
+    await setScenarioInputs(page, { supply: '100', borrow: '0' });
     await page.waitForTimeout(900);
 
     const rows = page.locator('tbody tr[data-reserve-id]');
     const rowCount = await rows.count();
     expect(rowCount, 'need visible reserve rows').toBeGreaterThan(0);
 
-    const targetIndex = Math.min(2, rowCount - 1);
+    const targetIndex = Math.min(8, rowCount - 1);
     const targetRow = rows.nth(targetIndex);
     const reserveId = await targetRow.getAttribute('data-reserve-id');
     if (!reserveId) throw new Error(`Missing data-reserve-id at index ${targetIndex}`);
@@ -81,85 +138,68 @@ test.describe('Simulation fully visible after scenario-driven pin (desktop)', ()
     await expect(targetRow).toHaveClass(/bg-muted\/30/);
     await page.waitForTimeout(500);
 
-    await borrowInput.fill('100');
-
     const expandedMain = page.locator(`tbody tr[data-reserve-id="${reserveId}"]`).first();
     await expect(expandedMain).toBeVisible({ timeout: 10_000 });
+    const scenarioSteps = [
+      { supply: '250', borrow: '0' },
+      { supply: '0', borrow: '250' },
+      { supply: '1000', borrow: '150' },
+      { supply: '80', borrow: '1200' },
+      { supply: '30000', borrow: '50' },
+      { supply: '40', borrow: '45000' },
+      { supply: '700', borrow: '700' },
+      { supply: '150000', borrow: '900' },
+    ];
 
-    /** Match `reserves-table-scenario-pin.spec.ts`: pin band is fixed per assert; poll row `y` only (re-calling sticky boxes inside poll can see transient null → bogus default). */
-    const assertPinned = async (label: string) => {
+    let observedPin = false;
+    for (const step of scenarioSteps) {
+      const beforeOrder = await getVisibleReserveOrder(page);
+      await moveRowAwayFromPinBand(page, reserveId);
+      await resetScrollByProbe(page);
+      await setScenarioInputs(page, step);
+      await page.waitForTimeout(1200);
+      const afterOrder = await getVisibleReserveOrder(page);
+      if (!didReorder(beforeOrder, afterOrder)) continue;
+
+      await expect
+        .poll(() => getScrollByProbeCount(page), {
+          timeout: 15_000,
+          message: 'a scenario-driven reorder should trigger pin scrolling',
+        })
+        .toBeGreaterThan(0);
+
       const pinnedTopY = await getPinnedTopY(page);
       await expect
         .poll(
           async () => {
-            const b = await expandedMain.boundingBox();
-            return b ? b.y : Number.POSITIVE_INFINITY;
+            const box = await expandedMain.boundingBox();
+            return box ? box.y : Number.POSITIVE_INFINITY;
           },
-          { timeout: 15_000, message: label },
+          {
+            timeout: 15_000,
+            message: 'expanded row should pin after an observed scenario-driven reorder',
+          },
         )
         .toBeLessThanOrEqual(pinnedTopY + 28);
-    };
+      observedPin = true;
+      break;
+    }
 
-    await assertPinned('expanded row should pin after first scenario-driven re-sort');
-
-    await supplyInput.fill('10000000');
-    await page.waitForTimeout(1100);
-    await assertPinned('expanded row should stay pinned after second scenario-driven re-sort');
-
-    await page.waitForTimeout(400);
-
+    expect(observedPin, 'a scenario step must reorder and pin the expanded reserve').toBe(true);
     await expect(page.getByText('Simulation is for reference only')).toBeVisible({ timeout: 25_000 });
 
     const scrollPort = simulationScrollPortForMainRow(expandedMain);
     await expect(scrollPort).toBeVisible({ timeout: 10_000 });
 
-    // 1) E2E clamp: prove simulation content IS tall enough to overflow a small pane.
-    await scrollPort.evaluate((el) => {
-      el.dataset.e2ePrevMaxHeight = el.style.maxHeight;
-      el.dataset.e2ePrevOverflow = el.style.overflowY;
-      el.style.maxHeight = '180px';
-      el.style.overflowY = 'auto';
-    });
-
-    await expect
-      .poll(
-        async () => {
-          const { scrollHeight, clientHeight } = await scrollPort.evaluate((e) => ({
-            scrollHeight: e.scrollHeight,
-            clientHeight: e.clientHeight,
-          }));
-          return scrollHeight - clientHeight;
-        },
-        {
-          timeout: 15_000,
-          message:
-            'after E2E clamp: simulation content should exceed inner pane (see nested-scroll spec)',
-        },
-      )
-      .toBeGreaterThan(24);
-
-    // 2) Restore product state (no max-height, no overflow-y) and verify no inner scroll.
-    await scrollPort.evaluate((el) => {
-      el.style.maxHeight = el.dataset.e2ePrevMaxHeight ?? '';
-      el.style.overflowY = el.dataset.e2ePrevOverflow ?? '';
-      delete el.dataset.e2ePrevMaxHeight;
-      delete el.dataset.e2ePrevOverflow;
-    });
-
     const metrics = await scrollPort.evaluate((el) => ({
       scrollHeight: el.scrollHeight,
       clientHeight: el.clientHeight,
+      overflowY: getComputedStyle(el).overflowY,
     }));
 
     expect(
-      metrics.scrollHeight,
-      'tall simulation body expected after large scenario (raise supply if this fails)',
-    ).toBeGreaterThan(320);
-
-    expect(
-      metrics.scrollHeight,
-      `Expected entire simulation visible without inner scroll after pin (scrollHeight=${metrics.scrollHeight} <= clientHeight=${metrics.clientHeight}). ` +
-        'Remove or relax DesktopReserveRow max-height + overflow-y-auto so this passes.',
-    ).toBeLessThanOrEqual(metrics.clientHeight + 2);
+      metrics.scrollHeight - metrics.clientHeight,
+      `simulation should remain on document scroll after pin (overflow-y=${metrics.overflowY})`,
+    ).toBeLessThanOrEqual(2);
   });
 });

--- a/e2e/reserves-table-simulation-nested-scroll.spec.ts
+++ b/e2e/reserves-table-simulation-nested-scroll.spec.ts
@@ -4,7 +4,6 @@ async function waitDesktopTable(page: Parameters<typeof test>[0]['page']) {
   await expect(page.locator('tbody tr[data-reserve-id]').first()).toBeVisible();
 }
 
-/** Inner scrollport wrapping `SimulationSubRow` (desktop expanded row). */
 function simulationScrollPort(mainRow: Locator) {
   return mainRow.locator('xpath=following-sibling::tr[1]').locator('[data-reserves-simulation-scrollport]').first();
 }
@@ -13,203 +12,81 @@ async function readInnerScrollMetrics(scrollPort: Locator) {
   return scrollPort.evaluate((el) => ({
     scrollTop: el.scrollTop,
     maxScroll: Math.max(0, el.scrollHeight - el.clientHeight),
+    overflowY: getComputedStyle(el).overflowY,
   }));
 }
 
-test.describe('Reserves simulation nested scroll (desktop)', () => {
-  test.beforeEach(async ({ page: _page }, testInfo) => {
-    test.skip(
-      testInfo.project.name.includes('mobile'),
-      'Desktop expanded row uses inner max-height scrollport',
-    );
-  });
+async function openExpandedSimulation(page: Parameters<typeof test>[0]['page']) {
+  await page.goto('/');
+  await waitDesktopTable(page);
 
-  /**
-   * Documents guardrails behavior: the expanded simulation sits in `overflow-y-auto` with
-   * `max-height` (`DesktopReserveRow`). Wheel over that pane prefers inner `scrollTop`; wheel
-   * over the sticky scenario strip moves `window` — same debounced scenario, different targets.
-   */
-  test('wheel over simulation inner pane scrolls inner scrollTop; wheel over scenario strip scrolls window', async ({
+  const supplyInput = page.locator(
+    '[data-reserves-sticky-scenario] input[aria-label="Supply amount"]',
+  );
+  await supplyInput.fill('10000000');
+  await page.waitForTimeout(1000);
+
+  const mainRow = page.locator('tbody tr[data-reserve-id]').first();
+  await mainRow.click();
+  await expect(page.getByText('Simulation is for reference only')).toBeVisible({ timeout: 20_000 });
+
+  const scrollPort = simulationScrollPort(mainRow);
+  await expect(scrollPort).toBeVisible();
+  return { scrollPort, supplyInput };
+}
+
+test.describe('Reserves simulation document scroll (desktop)', () => {
+  test('wheel over simulation scrolls the document without inner vertical overflow', async ({
     page,
   }) => {
-    await page.goto('/');
-    await waitDesktopTable(page);
+    const { scrollPort } = await openExpandedSimulation(page);
+    const before = await readInnerScrollMetrics(scrollPort);
 
-    const supplyInput = page.locator('[data-reserves-sticky-scenario] input[aria-label="Supply amount"]');
-    await supplyInput.fill('10000000');
-    await page.waitForTimeout(1000);
+    expect(before.maxScroll, 'simulation must not create an inner vertical scroll range').toBeLessThanOrEqual(2);
+    expect(before.overflowY, 'simulation must not use an inner vertical scrollport').not.toMatch(
+      /^(auto|scroll)$/,
+    );
 
-    const mainRow = page.locator('tbody tr[data-reserve-id]').first();
-    await mainRow.click();
-    await expect(page.getByText('Simulation is for reference only')).toBeVisible({ timeout: 20_000 });
+    await scrollPort.hover();
+    const windowBefore = await page.evaluate(() => window.scrollY);
+    await page.mouse.wheel(0, 700);
+    await expect
+      .poll(() => page.evaluate(() => window.scrollY), {
+        timeout: 4000,
+        message: 'wheel over the simulation should move the document',
+      })
+      .toBeGreaterThan(windowBefore + 24);
 
-    const scrollPort = simulationScrollPort(mainRow);
-    await expect(scrollPort).toBeVisible();
+    const after = await readInnerScrollMetrics(scrollPort);
+    expect(after.scrollTop, 'wheel must not be absorbed by the simulation wrapper').toBeLessThanOrEqual(1);
+  });
 
-    // Tighten max-height so overflow is deterministic across reserves/API payloads (assertion is wheel routing, not exact layout px).
-    await scrollPort.evaluate((el) => {
-      el.dataset.e2ePrevMaxHeight = el.style.maxHeight;
-      el.dataset.e2ePrevOverflow = el.style.overflowY;
-      el.style.maxHeight = '140px';
-      el.style.overflowY = 'auto';
-    });
-    const hasOverflow = await scrollPort.evaluate((el) => el.scrollHeight > el.clientHeight + 24);
-    expect(hasOverflow, 'simulation scrollport should overflow after E2E max-height clamp').toBe(true);
+  test('consecutive wheels keep inner scrollTop at zero while the scenario stays unchanged', async ({
+    page,
+  }) => {
+    const { scrollPort, supplyInput } = await openExpandedSimulation(page);
+    const initialScenario = await supplyInput.inputValue();
+    const initialWindowY = await page.evaluate(() => window.scrollY);
 
-    try {
-      const strip = page.locator('[data-reserves-sticky-scenario]').first();
-      await strip.hover();
-      const wBeforeStrip = await page.evaluate(() => window.scrollY);
-      await page.mouse.wheel(0, 700);
+    for (let gesture = 1; gesture <= 2; gesture += 1) {
+      await scrollPort.hover();
+      const windowBefore = await page.evaluate(() => window.scrollY);
+      await page.mouse.wheel(0, 350);
       await expect
         .poll(() => page.evaluate(() => window.scrollY), {
           timeout: 4000,
-          message: 'window scrollY should change after wheel on scenario strip',
+          message: `document should advance after wheel gesture ${gesture}`,
         })
-        .not.toBe(wBeforeStrip);
-      const wAfterStrip = await page.evaluate(() => window.scrollY);
-      const deltaStrip = Math.abs(wAfterStrip - wBeforeStrip);
-      expect(deltaStrip, 'scenario strip wheel should move the document').toBeGreaterThan(24);
+        .toBeGreaterThan(windowBefore + 12);
 
-      await scrollPort.evaluate((el) => {
-        el.scrollTop = 0;
-      });
-      await page.evaluate((y) => window.scrollTo(0, y), wBeforeStrip);
-      await page.waitForTimeout(200);
-
-      await scrollPort.hover();
-      const wBeforeInner = await page.evaluate(() => window.scrollY);
-      const innerBefore = await scrollPort.evaluate((el) => el.scrollTop);
-      await page.mouse.wheel(0, 700);
-      await expect
-        .poll(() => scrollPort.evaluate((el) => el.scrollTop), {
-          timeout: 4000,
-          message: 'inner scrollTop should increase after wheel on simulation pane',
-        })
-        .toBeGreaterThan(innerBefore + 20);
-
-      const wAfterInner = await page.evaluate(() => window.scrollY);
-      const innerAfter = await scrollPort.evaluate((el) => el.scrollTop);
-      const deltaWindowInner = Math.abs(wAfterInner - wBeforeInner);
-      const deltaInner = innerAfter - innerBefore;
-
-      expect(deltaInner, 'simulation pane should absorb downward wheel into scrollTop').toBeGreaterThan(40);
+      const metrics = await readInnerScrollMetrics(scrollPort);
       expect(
-        deltaWindowInner,
-        'window should move less when wheeling over inner simulation than strip wheel delta (nested scrollport)',
-      ).toBeLessThan(deltaStrip * 0.85);
-    } finally {
-      await scrollPort.evaluate((el) => {
-        el.style.maxHeight = el.dataset.e2ePrevMaxHeight ?? '';
-        el.style.overflowY = el.dataset.e2ePrevOverflow ?? '';
-        delete el.dataset.e2ePrevMaxHeight;
-        delete el.dataset.e2ePrevOverflow;
-      });
+        metrics.scrollTop,
+        `wheel gesture ${gesture} must not advance an inner scroll position`,
+      ).toBeLessThanOrEqual(1);
     }
-  });
-});
 
-/**
- * Locks the **mechanism** behind the reported issue: shared scenario inputs do **not** change,
- * yet consecutive wheels over the gray simulation pane keep advancing **`scrollTop` on the inner
- * scrollport** — bottom content (`data-reserves-simulation-bottom-sentinel`) stays below the fold
- * until the user scrolls **inside** that pane. This is why a second gesture can feel “obscured”
- * even when debounced scenario is unchanged.
- */
-test.describe('Repro: same-scenario double wheel on simulation (inner scroll advances)', () => {
-  test.beforeEach(async ({ page: _page }, testInfo) => {
-    test.skip(
-      testInfo.project.name.includes('mobile'),
-      'Desktop expanded row inner scrollport only',
-    );
-  });
-
-  test('two wheels on simulation without changing scenario — inner scrollTop increases twice and bottom stays below fold', async ({
-    page,
-  }) => {
-    await page.goto('/');
-    await waitDesktopTable(page);
-
-    const supplyInput = page.locator('[data-reserves-sticky-scenario] input[aria-label="Supply amount"]');
-    await supplyInput.fill('10000000');
-    await page.waitForTimeout(1000);
-
-    const mainRow = page.locator('tbody tr[data-reserve-id]').first();
-    await mainRow.click();
-    await expect(page.getByText('Simulation is for reference only')).toBeVisible({ timeout: 20_000 });
-
-    const scrollPort = simulationScrollPort(mainRow);
-    await expect(scrollPort).toBeVisible();
-
-    await scrollPort.evaluate((el) => {
-      el.dataset.e2ePrevMaxHeight = el.style.maxHeight;
-      el.dataset.e2ePrevOverflow = el.style.overflowY;
-      el.style.maxHeight = '160px';
-      el.style.overflowY = 'auto';
-    });
-
-    try {
-      await scrollPort.evaluate((el) => {
-        el.scrollTop = 0;
-      });
-
-      const m0 = await readInnerScrollMetrics(scrollPort);
-      expect(m0.maxScroll, 'inner pane must overflow').toBeGreaterThan(40);
-
-      await scrollPort.hover();
-      await page.mouse.wheel(0, 500);
-      await page.waitForTimeout(200);
-      const m1 = await readInnerScrollMetrics(scrollPort);
-      expect(m1.scrollTop, 'first wheel on simulation should advance inner scrollTop').toBeGreaterThan(m0.scrollTop);
-
-      const wBeforeSecond = await page.evaluate(() => window.scrollY);
-      await page.mouse.wheel(0, 500);
-      await page.waitForTimeout(250);
-      const m2 = await readInnerScrollMetrics(scrollPort);
-      const wAfterSecond = await page.evaluate(() => window.scrollY);
-
-      const innerStillAdvances = m2.scrollTop > m1.scrollTop + 0.5;
-      const innerMaxed =
-        m1.maxScroll > 0 && m1.scrollTop >= m1.maxScroll - 2 && m2.scrollTop >= m1.scrollTop - 2;
-      const secondWheelSpillsToWindow =
-        innerMaxed && Math.abs(wAfterSecond - wBeforeSecond) > 12;
-
-      expect(
-        innerStillAdvances || secondWheelSpillsToWindow,
-        'second wheel: either inner scrollTop increases again, or inner is maxed and window scrollY moves (nested-scroll handoff)',
-      ).toBe(true);
-
-      expect(m2.scrollTop - m0.scrollTop, 'accumulated inner scroll without scenario change').toBeGreaterThan(40);
-
-      // From top: a modest first wheel must not max inner; bottom sentinel still lies below the inner fold (same scenario).
-      await scrollPort.evaluate((el) => {
-        el.scrollTop = 0;
-      });
-      await scrollPort.hover();
-      await page.mouse.wheel(0, 160);
-      await page.waitForTimeout(200);
-      const mPartial = await readInnerScrollMetrics(scrollPort);
-      expect(mPartial.scrollTop, 'partial wheel should move inner').toBeGreaterThan(8);
-      expect(mPartial.scrollTop, 'leave headroom so sentinel can stay below fold').toBeLessThan(mPartial.maxScroll - 8);
-
-      const sentinelPastFoldAfterPartial = await scrollPort.evaluate((port) => {
-        const sent = port.querySelector('[data-reserves-simulation-bottom-sentinel]');
-        if (!(sent instanceof HTMLElement)) return false;
-        const pr = port.getBoundingClientRect();
-        const sr = sent.getBoundingClientRect();
-        return sr.bottom > pr.bottom + 0.5;
-      });
-      expect(
-        sentinelPastFoldAfterPartial,
-        'after partial wheel: bottom sentinel still below inner client bottom',
-      ).toBe(true);
-    } finally {
-      await scrollPort.evaluate((el) => {
-        el.style.maxHeight = el.dataset.e2ePrevMaxHeight ?? '';
-        el.style.overflowY = el.dataset.e2ePrevOverflow ?? '';
-        delete el.dataset.e2ePrevMaxHeight;
-        delete el.dataset.e2ePrevOverflow;
-      });
-    }
+    expect(await supplyInput.inputValue()).toBe(initialScenario);
+    expect(await page.evaluate(() => window.scrollY)).toBeGreaterThan(initialWindowY + 24);
   });
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -33,6 +33,10 @@ export default defineConfig({
     },
     {
       name: 'mobile-chromium',
+      testIgnore: [
+        /reserves-table-simulation-full-after-scenario-pin\.spec\.ts/,
+        /reserves-table-simulation-nested-scroll\.spec\.ts/,
+      ],
       use: {
         ...devices['Pixel 7'],
       },

--- a/src/hooks/useRateSimulation.hook.test.tsx
+++ b/src/hooks/useRateSimulation.hook.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment happy-dom
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useSharedRateSimulations } from './useRateSimulation';
+
+vi.mock('@tanstack/react-query', () => ({
+  useQueries: () => [],
+}));
+
+vi.mock('@/hooks/useSideDataMeta', () => ({
+  useSideDataMeta: () => ({
+    data: undefined,
+    isPending: false,
+    isFetching: false,
+  }),
+}));
+
+describe('useSharedRateSimulations', () => {
+  it('reports when a shared scenario input is active', () => {
+    const { result } = renderHook(() =>
+      useSharedRateSimulations({
+        reserves: [],
+        isApy: true,
+        whitelistMerklCampaignIds: new Set(),
+        tydroPointToUsdRate: 0,
+        supplyInput: '100',
+        borrowInput: '',
+      }),
+    );
+
+    expect(result.current.hasAnyInput).toBe(true);
+  });
+
+  it('reports when a portfolio member has a negative delta', () => {
+    const { result } = renderHook(() =>
+      useSharedRateSimulations({
+        reserves: [],
+        isApy: true,
+        whitelistMerklCampaignIds: new Set(),
+        tydroPointToUsdRate: 0,
+        supplyInput: '',
+        borrowInput: '',
+        perReserveInputs: new Map([
+          [
+            'reserve-1',
+            {
+              supplyInput: '-100',
+              borrowInput: '0',
+              inputMode: 'usd',
+              totalSupplyUsd: 900,
+            },
+          ],
+        ]),
+      }),
+    );
+
+    expect(result.current.hasAnyInput).toBe(true);
+  });
+});

--- a/src/hooks/useRateSimulation.ts
+++ b/src/hooks/useRateSimulation.ts
@@ -5,7 +5,7 @@ import { QUERY_STALE_TIMES } from '@/config/queryStaleTimes';
 import { hasRateCalcFields } from '@/lib/interestRateCalculator';
 import type { RateCalcInput } from '@/lib/interestRateCalculator';
 import { shouldSurfaceForecastError } from '@/lib/merklForecastErrors';
-import { parseNumberInput } from '@/lib/numberFormat';
+import { parseSignedNumberInput } from '@/lib/numberFormat';
 import { resolveForecastTokenPriceWithBackup } from '@/lib/tokenPriceResolver';
 import type {
   MerklForecastWireItem,
@@ -104,14 +104,16 @@ export const useSharedRateSimulations = ({
     () =>
       perReserveInputs != null &&
       Array.from(perReserveInputs.values()).some(
-        (v) => parseNumberInput(v.supplyInput) > 0 || parseNumberInput(v.borrowInput) > 0,
+        (v) =>
+          parseSignedNumberInput(v.supplyInput) !== 0 ||
+          parseSignedNumberInput(v.borrowInput) !== 0,
       ),
     [perReserveInputs],
   );
   const hasAnyInput = useMemo(
     () =>
-      parseNumberInput(supplyInput) > 0 ||
-      parseNumberInput(borrowInput) > 0 ||
+      parseSignedNumberInput(supplyInput) !== 0 ||
+      parseSignedNumberInput(borrowInput) !== 0 ||
       hasPerReserveInput,
     [borrowInput, supplyInput, hasPerReserveInput],
   );
@@ -137,10 +139,11 @@ export const useSharedRateSimulations = ({
       const reserveId = getReserveSimulationId(reserve);
       const perReserve = perReserveInputs?.get(reserveId);
       const reserveNeedsPrice =
-        parseNumberInput(supplyInput) > 0 ||
-        parseNumberInput(borrowInput) > 0 ||
+        parseSignedNumberInput(supplyInput) !== 0 ||
+        parseSignedNumberInput(borrowInput) !== 0 ||
         (perReserve != null &&
-          (parseNumberInput(perReserve.supplyInput) > 0 || parseNumberInput(perReserve.borrowInput) > 0));
+          (parseSignedNumberInput(perReserve.supplyInput) !== 0 ||
+            parseSignedNumberInput(perReserve.borrowInput) !== 0));
       const localPriceMissing = localPrice === undefined;
       const queryKey = [
         ...FORECAST_TOKEN_PRICE_QUERY_KEY,
@@ -288,13 +291,16 @@ export const useSharedRateSimulations = ({
         }
       }
       const hasEffectiveInput =
-        parseNumberInput(effectiveSupplyInput) > 0 || parseNumberInput(effectiveBorrowInput) > 0;
+        parseSignedNumberInput(effectiveSupplyInput) !== 0 ||
+        parseSignedNumberInput(effectiveBorrowInput) !== 0;
       // AAV-1166: Portfolio Scenario active when any perReserve entry has a delta
       // and the current reserve is a portfolio member.
       const portfolioScenarioActive =
         perReserveInputs != null &&
         Array.from(perReserveInputs.values()).some(
-          (v) => parseNumberInput(v.supplyInput) > 0 || parseNumberInput(v.borrowInput) > 0,
+          (v) =>
+            parseSignedNumberInput(v.supplyInput) !== 0 ||
+            parseSignedNumberInput(v.borrowInput) !== 0,
         ) &&
         perReserveInputs.has(reserveId);
 
@@ -363,6 +369,7 @@ export const useSharedRateSimulations = ({
 
   return {
     simulationsById,
+    hasAnyInput,
     forecastLoading: hasAnyInput && forecastLoading,
     forecastErrors,
   };

--- a/src/lib/interestRateCalculator.ts
+++ b/src/lib/interestRateCalculator.ts
@@ -92,14 +92,17 @@ function aprPercentToApyPercent(aprPercent: number): number {
 function parseUnits(amount: string, decimals: number): bigint {
   const cleaned = amount.replace(/,/g, '').trim();
   if (!cleaned) return 0n;
-  if (!/^\d*\.?\d*$/.test(cleaned)) return 0n;
-  const [intRaw, fracRaw = ''] = cleaned.split('.');
+  const negative = cleaned.startsWith('-');
+  const unsigned = negative ? cleaned.slice(1) : cleaned;
+  if (!/^\d*\.?\d*$/.test(unsigned)) return 0n;
+  const [intRaw, fracRaw = ''] = unsigned.split('.');
   const intPart = intRaw || '0';
   const safeDecimals = Math.max(0, Math.floor(decimals));
   const scale = 10n ** BigInt(safeDecimals);
   const fracPadded = (fracRaw + '0'.repeat(safeDecimals)).slice(0, safeDecimals);
   const fracPart = fracPadded ? BigInt(fracPadded) : 0n;
-  return BigInt(intPart) * scale + fracPart;
+  const parsed = BigInt(intPart) * scale + fracPart;
+  return negative ? -parsed : parsed;
 }
 
 export interface NativeRateSimulation {

--- a/src/lib/numberFormat.ts
+++ b/src/lib/numberFormat.ts
@@ -48,3 +48,8 @@ export const parseNumberInput = (value: string): number => {
   const parsed = Number(sanitized);
   return Number.isFinite(parsed) ? parsed : 0;
 };
+
+export const parseSignedNumberInput = (value: string): number => {
+  const parsed = parseNumberInput(value);
+  return value.trim().startsWith('-') ? -parsed : parsed;
+};

--- a/src/lib/portfolioSimulator.test.ts
+++ b/src/lib/portfolioSimulator.test.ts
@@ -347,6 +347,40 @@ describe('buildPerReserveInputsFromEntries', () => {
     expect(result.reserveSymbolById!.get(reserveId)).toBe('USDC');
   });
 
+  it('keeps after metrics active for unchanged members after another member withdraws', () => {
+    const withdrawingReserveId = 'r-withdrawing';
+    const unchangedReserveId = 'r-unchanged';
+    const reserves = [
+      makeRateCalcReserve({ reserveId: withdrawingReserveId, tokenSymbol: 'USDC' }),
+      makeRateCalcReserve({ reserveId: unchangedReserveId, tokenSymbol: 'USDT' }),
+    ];
+    const entries = [
+      makeEntry({
+        reserveId: withdrawingReserveId,
+        tokenSymbol: 'USDC',
+        supply: { amount: '500', inputMode: 'usd', walletValue: 1000 },
+        borrow: { ...emptySide },
+      }),
+      makeEntry({
+        reserveId: unchangedReserveId,
+        tokenSymbol: 'USDT',
+        supply: { amount: '1000', inputMode: 'usd', walletValue: 1000 },
+        borrow: { ...emptySide },
+      }),
+    ];
+
+    const { results } = simulatePortfolioFromEntries(
+      baseEntriesSimArgs({ entries, reserves }),
+    );
+
+    const unchangedSupply = results.find(
+      (result) => result.reserveId === unchangedReserveId && result.side === 'supply',
+    );
+    expect(unchangedSupply?.nativeMetric?.after).not.toBeNull();
+    expect(unchangedSupply?.incentiveMetric?.after).not.toBeNull();
+    expect(unchangedSupply?.totalMetric?.after).not.toBeNull();
+  });
+
   it('manual position (walletValue=null): delta=full amount, principal=full amount', () => {
     const reserveId = 'r-usdc';
     const reserve = makeRateCalcReserve({ reserveId, tokenSymbol: 'USDC', tokenPrice: 1 });

--- a/src/lib/portfolioSimulator.ts
+++ b/src/lib/portfolioSimulator.ts
@@ -223,7 +223,7 @@ function computeResultsFromGroups(
   // AAV-1166: Portfolio Scenario is active when any portfolio entry has a non-zero delta.
   // All portfolio members (every group in groupMap) compute after* values.
   const portfolioScenarioActive = Array.from(groupMap.values()).some(
-    (g) => g.supplyDeltaUsd > 0 || g.borrowDeltaUsd > 0,
+    (g) => g.supplyDeltaUsd !== 0 || g.borrowDeltaUsd !== 0,
   );
 
   for (const [key, group] of groupMap) {

--- a/src/lib/rateSimulationCalculator.test.ts
+++ b/src/lib/rateSimulationCalculator.test.ts
@@ -168,6 +168,34 @@ describe('A/B category: B-class fields (after/delta)', () => {
     expect(result.marketMetrics.totalBorrowedUsdAfter).not.toBeNull();
   });
 
+  it('applies a negative portfolio supply delta as a withdrawal', () => {
+    const deposit = buildRateSimulationResult({
+      reserve: BASE_RESERVE,
+      reserveRateInput: VALID_RATE_INPUT,
+      ...BASE_PARAMS,
+      supplyInput: '1000',
+    });
+    const withdrawal = buildRateSimulationResult({
+      reserve: BASE_RESERVE,
+      reserveRateInput: VALID_RATE_INPUT,
+      ...BASE_PARAMS,
+      supplyInput: '-1000',
+    });
+
+    expect(withdrawal.utilization.after).toBeGreaterThan(deposit.utilization.after!);
+  });
+
+  it('caps a withdrawal at executable reserve liquidity for native rate simulation', () => {
+    const result = buildRateSimulationResult({
+      reserve: BASE_RESERVE,
+      reserveRateInput: VALID_RATE_INPUT,
+      ...BASE_PARAMS,
+      supplyInput: '-100000',
+    });
+
+    expect(result.utilization.after).toBeCloseTo(100, 6);
+  });
+
   it('B-class fields are null in fallback path (reserveRateInput null, no input)', () => {
     const result = buildRateSimulationResult({
       reserve: BASE_RESERVE,
@@ -1022,7 +1050,9 @@ describe('AAV-916: buildMeritCampaignDetails position cap capNote', () => {
   ];
 
   it('generates capNote when deposit exceeds self-position cap', () => {
-    const rows = buildMeritCampaignDetails(merits, false, 5000, true);
+    const rows = buildMeritCampaignDetails({
+      merits, isApy: false, inputUsd: 5000, shouldComputeAfter: true,
+    });
     const selfRow = rows.find((r) => r.id === 'merit-0-1');
     expect(selfRow).toBeDefined();
     expect(selfRow!.notes?.[0]?.text).toBeDefined();
@@ -1030,7 +1060,9 @@ describe('AAV-916: buildMeritCampaignDetails position cap capNote', () => {
   });
 
   it('generates capNote but no capWarning when deposit is below cap', () => {
-    const rows = buildMeritCampaignDetails(merits, false, 500, true);
+    const rows = buildMeritCampaignDetails({
+      merits, isApy: false, inputUsd: 500, shouldComputeAfter: true,
+    });
     const selfRow = rows.find((r) => r.id === 'merit-0-1');
     expect(selfRow).toBeDefined();
     expect(selfRow!.notes?.[0]?.text).toBeDefined();
@@ -1072,7 +1104,9 @@ describe('buildMerklCampaignDetails — forecastUnavailable flag', () => {
     const forecastStates: Record<string, import('@/types/aave').MerklForecastWireItem> = {
       'camp-with-forecast': { requiredDaily: 100, distributedSoFar: 50, endTimestamp: 2000000000 },
     };
-    const rows = buildMerklCampaignDetails(opportunities, false, 1000, forecastStates, undefined, 1, true);
+    const rows = buildMerklCampaignDetails({
+      opportunities, isApy: false, inputUsd: 1000, forecastStates, tydroPointToUsdRate: 1, shouldComputeAfter: true,
+    });
     const withoutForecast = rows.find((r) => r.id.includes('camp-without-forecast'));
     expect(withoutForecast).toBeDefined();
     expect(withoutForecast!.forecastUnavailable).toBe(true);
@@ -1083,7 +1117,9 @@ describe('buildMerklCampaignDetails — forecastUnavailable flag', () => {
     const forecastStates: Record<string, import('@/types/aave').MerklForecastWireItem> = {
       'camp-with-forecast': { requiredDaily: 100, distributedSoFar: 50, endTimestamp: 2000000000 },
     };
-    const rows = buildMerklCampaignDetails(opportunities, false, 1000, forecastStates, undefined, 1, true);
+    const rows = buildMerklCampaignDetails({
+      opportunities, isApy: false, inputUsd: 1000, forecastStates, tydroPointToUsdRate: 1, shouldComputeAfter: true,
+    });
     const withForecast = rows.find((r) => r.id.includes('camp-with-forecast'));
     expect(withForecast).toBeDefined();
     expect(withForecast!.forecastUnavailable).toBeFalsy();
@@ -1091,7 +1127,9 @@ describe('buildMerklCampaignDetails — forecastUnavailable flag', () => {
 
   it('marks campaign as forecastUnavailable when mergeForecastState returns null (no campaignId)', () => {
     const forecastStates: Record<string, import('@/types/aave').MerklForecastWireItem> = {};
-    const rows = buildMerklCampaignDetails(opportunities, false, 1000, forecastStates, undefined, 1, true);
+    const rows = buildMerklCampaignDetails({
+      opportunities, isApy: false, inputUsd: 1000, forecastStates, tydroPointToUsdRate: 1, shouldComputeAfter: true,
+    });
     const noIdRow = rows.find((r) => r.id.includes('-x'));
     expect(noIdRow).toBeDefined();
     expect(noIdRow!.forecastUnavailable).toBe(true);
@@ -1100,7 +1138,9 @@ describe('buildMerklCampaignDetails — forecastUnavailable flag', () => {
 
   it('sets forecastUnavailable flag even when hasAnyInput is false (capNote not affected)', () => {
     const forecastStates: Record<string, import('@/types/aave').MerklForecastWireItem> = {};
-    const rows = buildMerklCampaignDetails(opportunities, false, 1000, forecastStates, undefined, 1, false);
+    const rows = buildMerklCampaignDetails({
+      opportunities, isApy: false, inputUsd: 1000, forecastStates, tydroPointToUsdRate: 1, shouldComputeAfter: false,
+    });
     const unavailableRows = rows.filter((r) => r.forecastUnavailable);
     expect(unavailableRows.length).toBeGreaterThan(0);
     for (const row of rows) {
@@ -1132,11 +1172,18 @@ describe('buildMerklCampaignDetails — position cap native amount display', () 
     const forecastStates: Record<string, import('@/types/aave').MerklForecastWireItem> = {
       'merkl-capped': { requiredDaily: 100, distributedSoFar: 0, endTimestamp: 2000000000 },
     };
-    const rows = buildMerklCampaignDetails(
-      opportunitiesWithPositionCap, false, 5000, forecastStates,
-      undefined, 1, true, 1, undefined, undefined, undefined, undefined, undefined, undefined,
-      undefined, undefined, 1, 6, 'USDT',
-    );
+    const rows = buildMerklCampaignDetails({
+      opportunities: opportunitiesWithPositionCap,
+      isApy: false,
+      inputUsd: 5000,
+      forecastStates,
+      tydroPointToUsdRate: 1,
+      shouldComputeAfter: true,
+      eligibilityRatio: 1,
+      tokenPrice: 1,
+      decimals: 6,
+      tokenSymbol: 'USDT',
+    });
     const cappedRow = rows.find((r) => r.id.includes('merkl-capped'));
     expect(cappedRow).toBeDefined();
     const capNote = cappedRow!.notes?.find((n) => n.type === 'position_cap');
@@ -1149,11 +1196,17 @@ describe('buildMerklCampaignDetails — position cap native amount display', () 
     const forecastStates: Record<string, import('@/types/aave').MerklForecastWireItem> = {
       'merkl-capped': { requiredDaily: 100, distributedSoFar: 0, endTimestamp: 2000000000 },
     };
-    const rows = buildMerklCampaignDetails(
-      opportunitiesWithPositionCap, false, 5000, forecastStates,
-      undefined, 1, true, 1, undefined, undefined, undefined, undefined, undefined, undefined,
-      undefined, undefined, 1, 6,
-    );
+    const rows = buildMerklCampaignDetails({
+      opportunities: opportunitiesWithPositionCap,
+      isApy: false,
+      inputUsd: 5000,
+      forecastStates,
+      tydroPointToUsdRate: 1,
+      shouldComputeAfter: true,
+      eligibilityRatio: 1,
+      tokenPrice: 1,
+      decimals: 6,
+    });
     const cappedRow = rows.find((r) => r.id.includes('merkl-capped'));
     expect(cappedRow).toBeDefined();
     const capNote = cappedRow!.notes?.find((n) => n.type === 'position_cap');
@@ -1182,14 +1235,11 @@ describe('buildMerklCampaignDetails — positionCap', () => {
         ],
       },
     ];
-    const rows = buildMerklCampaignDetails(
-      opportunities, /* isApy */ false, /* inputUsd */ 1000, forecastStates,
-      /* whitelistIds */ undefined, /* tydroRate */ 1, /* hasAnyInput */ true,
-      /* eligibilityRatio */ 1, /* grossInputUsd */ 1000,
-      /* merklGroupMultiplier */ undefined, /* merklCrossReserveNote */ undefined,
-      /* campaignAccessStatuses */ undefined, /* nativeApyPercent */ undefined,
-      /* pointRateMap */ undefined, /* grossForEligibility */ 1000, /* netForEligibility */ 1000,
-    );
+    const rows = buildMerklCampaignDetails({
+      opportunities, isApy: false, inputUsd: 1000, forecastStates, tydroPointToUsdRate: 1,
+      shouldComputeAfter: true, eligibilityRatio: 1, grossInputUsd: 1000,
+      grossForEligibility: 1000, netForEligibility: 1000,
+    });
     const row = rows[0];
     expect(row).toBeDefined();
     expect(row!.after).toBeLessThan(10);
@@ -1213,14 +1263,11 @@ describe('buildMerklCampaignDetails — positionCap', () => {
         ],
       },
     ];
-    const rows = buildMerklCampaignDetails(
-      opportunities, /* isApy */ false, /* inputUsd */ 1000, forecastStates,
-      /* whitelistIds */ undefined, /* tydroRate */ 1, /* hasAnyInput */ true,
-      /* eligibilityRatio */ 1, /* grossInputUsd */ 1000,
-      /* merklGroupMultiplier */ undefined, /* merklCrossReserveNote */ undefined,
-      /* campaignAccessStatuses */ undefined, /* nativeApyPercent */ undefined,
-      /* pointRateMap */ undefined, /* grossForEligibility */ 1000, /* netForEligibility */ 1000,
-    );
+    const rows = buildMerklCampaignDetails({
+      opportunities, isApy: false, inputUsd: 1000, forecastStates, tydroPointToUsdRate: 1,
+      shouldComputeAfter: true, eligibilityRatio: 1, grossInputUsd: 1000,
+      grossForEligibility: 1000, netForEligibility: 1000,
+    });
     const row = rows[0];
     expect(row).toBeDefined();
     expect(row!.after).toBeCloseTo(10, 1);
@@ -1244,14 +1291,11 @@ describe('buildMerklCampaignDetails — positionCap', () => {
         ],
       },
     ];
-    const rows = buildMerklCampaignDetails(
-      opportunities, /* isApy */ false, /* inputUsd */ 1000, forecastStates,
-      /* whitelistIds */ undefined, /* tydroRate */ 1, /* hasAnyInput */ true,
-      /* eligibilityRatio */ 1, /* grossInputUsd */ 2000,
-      /* merklGroupMultiplier */ undefined, /* merklCrossReserveNote */ undefined,
-      /* campaignAccessStatuses */ undefined, /* nativeApyPercent */ undefined,
-      /* pointRateMap */ undefined, /* grossForEligibility */ 2000, /* netForEligibility */ 1000,
-    );
+    const rows = buildMerklCampaignDetails({
+      opportunities, isApy: false, inputUsd: 1000, forecastStates, tydroPointToUsdRate: 1,
+      shouldComputeAfter: true, eligibilityRatio: 1, grossInputUsd: 2000,
+      grossForEligibility: 2000, netForEligibility: 1000,
+    });
     const row = rows[0];
     expect(row).toBeDefined();
     expect(row!.after).toBeLessThan(10);
@@ -1272,14 +1316,11 @@ describe('buildMerklCampaignDetails — positionCap', () => {
         ],
       },
     ];
-    const rows = buildMerklCampaignDetails(
-      opportunities, /* isApy */ false, /* inputUsd */ 1000, forecastStates,
-      /* whitelistIds */ undefined, /* tydroRate */ 1, /* hasAnyInput */ true,
-      /* eligibilityRatio */ 1, /* grossInputUsd */ 1000,
-      /* merklGroupMultiplier */ undefined, /* merklCrossReserveNote */ undefined,
-      /* campaignAccessStatuses */ undefined, /* nativeApyPercent */ undefined,
-      /* pointRateMap */ undefined, /* grossForEligibility */ 1000, /* netForEligibility */ 1000,
-    );
+    const rows = buildMerklCampaignDetails({
+      opportunities, isApy: false, inputUsd: 1000, forecastStates, tydroPointToUsdRate: 1,
+      shouldComputeAfter: true, eligibilityRatio: 1, grossInputUsd: 1000,
+      grossForEligibility: 1000, netForEligibility: 1000,
+    });
     const row = rows[0];
     expect(row).toBeDefined();
     expect(row!.after).toBeCloseTo(10, 1);
@@ -1302,7 +1343,9 @@ describe('buildBrevisCampaignDetails — forecastUnavailable flag', () => {
       },
     ];
     const forecastStates: Record<string, import('@/types/aave').MerklForecastWireItem> = {};
-    const rows = buildBrevisCampaignDetails(brevis, false, 1000, undefined, true, forecastStates);
+    const rows = buildBrevisCampaignDetails({
+      items: brevis, isApy: false, inputUsd: 1000, shouldComputeAfter: true, forecastStates,
+    });
     expect(rows.length).toBeGreaterThan(0);
     expect(rows[0].forecastUnavailable).toBe(true);
     expect(rows[0].notes?.[0]?.text ?? '').not.toContain('No forecast data');
@@ -1324,7 +1367,9 @@ describe('buildBrevisCampaignDetails — forecastUnavailable flag', () => {
     const forecastStates: Record<string, import('@/types/aave').MerklForecastWireItem> = {
       'brevis-1': { requiredDaily: 50, distributedSoFar: 20, endTimestamp: 2000000000 },
     };
-    const rows = buildBrevisCampaignDetails(brevis, false, 1000, undefined, true, forecastStates);
+    const rows = buildBrevisCampaignDetails({
+      items: brevis, isApy: false, inputUsd: 1000, shouldComputeAfter: true, forecastStates,
+    });
     expect(rows.length).toBeGreaterThan(0);
     expect(rows[0].forecastUnavailable).toBeFalsy();
   });
@@ -1367,12 +1412,12 @@ describe('Brevis position cap — totalPositionUsd fallback (AAV-1060 #10)', () 
   });
 
   it('buildBrevisCampaignDetails uses totalPositionUsd for position cap', () => {
-    const rowsWithTotal = buildBrevisCampaignDetails(
-      brevisWithCap, false, 0, undefined, true, undefined, 20000,
-    );
-    const rowsWithInputOnly = buildBrevisCampaignDetails(
-      brevisWithCap, false, 0, undefined, true, undefined, undefined,
-    );
+    const rowsWithTotal = buildBrevisCampaignDetails({
+      items: brevisWithCap, isApy: false, inputUsd: 0, shouldComputeAfter: true, totalPositionUsd: 20000,
+    });
+    const rowsWithInputOnly = buildBrevisCampaignDetails({
+      items: brevisWithCap, isApy: false, inputUsd: 0, shouldComputeAfter: true,
+    });
     expect(rowsWithTotal.length).toBe(1);
     expect(rowsWithInputOnly.length).toBe(1);
     expect(rowsWithTotal[0].current).toBe(10);
@@ -1881,6 +1926,54 @@ describe('AAV-1060: Merkl wallet position in net position constraint', () => {
     const noteText = merklNotes![0].text;
     expect(noteText).toContain('$1,042');
     expect(noteText).toContain('net eligible');
+  });
+});
+
+describe('AAV-1164: Merkl campaign details use unified eligibility', () => {
+  it('keeps the capped campaign row aligned with the Merkl source aggregate', () => {
+    const offsetReserveId = '1:0xoffset:0xoffset';
+    const reserve: ReserveWithSpread = {
+      ...BASE_RESERVE,
+      merklSupplys: [
+        {
+          name: 'Capped net lending',
+          breakdowns: [
+            {
+              campaignApr: 10,
+              campaignStartedAt: '2020-01-01T00:00:00.000Z',
+              campaignEndedAt: '2099-01-01T00:00:00.000Z',
+              campaignId: 'capped-net-lending',
+              positionCapUsd: 1000,
+            },
+          ],
+          netPositionConstraint: {
+            sourceSide: 'supply',
+            offsetReserveIds: [offsetReserveId],
+          },
+        },
+      ],
+    };
+    const result = buildRateSimulationResult({
+      reserve,
+      reserveRateInput: VALID_RATE_INPUT,
+      isApy: false,
+      whitelistMerklCampaignIds: undefined,
+      tydroPointToUsdRate: 1,
+      tokenPrice: 1,
+      supplyInput: '1500',
+      borrowInput: '0',
+      forecastStates: {},
+      meritMerklNetPosition: false,
+      totalSupplyUsd: 1500,
+      crossReservePositions: new Map([
+        [offsetReserveId, { supplyUsd: 0, borrowUsd: 500 }],
+      ]),
+    });
+
+    const campaign = result.supply.sources.merkl?.campaigns?.[0];
+    expect(campaign?.after).toBeCloseTo(6.667, 3);
+    expect(result.supply.sources.merkl?.after).toBeCloseTo(6.667, 3);
+    expect(result.supply.afterIncentive).toBeCloseTo(6.667, 3);
   });
 });
 
@@ -2958,6 +3051,8 @@ describe('AAV-1166: Portfolio Complete Snapshot (portfolioScenarioActive)', () =
     expect(result.supply.afterIncentive!).toBeCloseTo(result.supply.currentIncentive, 6);
     // delta should be 0 (no change from current in this scenario)
     expect(result.supply.deltaIncentive).toBeCloseTo(0, 6);
+    expect(result.supply.sources.merkl?.campaigns?.[0]?.after)
+      .toBeCloseTo(result.supply.sources.merkl?.after ?? 0, 6);
   });
 
   it('portfolioScenarioActive makes afterNative = currentNative when no local input', () => {
@@ -2981,6 +3076,26 @@ describe('AAV-1166: Portfolio Complete Snapshot (portfolioScenarioActive)', () =
     expect(result.supply.hasInput).toBe(false);
     expect(result.supply.afterNative).toBe(result.supply.currentNative);
     expect(result.supply.deltaNative).toBe(0);
+  });
+
+  it('withdrawal campaign details reconcile with their Merkl source after value', () => {
+    const result = buildRateSimulationResult({
+      reserve: makeReserveWithCrossConstraint(),
+      reserveRateInput: VALID_RATE_INPUT,
+      isApy: false,
+      whitelistMerklCampaignIds: undefined,
+      tydroPointToUsdRate: 1,
+      tokenPrice: 1,
+      supplyInput: '-500',
+      borrowInput: '0',
+      forecastStates: {},
+      totalSupplyUsd: 1000,
+      walletSupplyUsd: 1500,
+      portfolioScenarioActive: true,
+    });
+
+    expect(result.supply.sources.merkl?.campaigns?.[0]?.after)
+      .toBeCloseTo(result.supply.sources.merkl?.after ?? 0, 6);
   });
 
   it('currentIncentive unchanged when toggling portfolioScenarioActive (Golden Rule #1)', () => {

--- a/src/lib/rateSimulationCalculator.ts
+++ b/src/lib/rateSimulationCalculator.ts
@@ -49,7 +49,7 @@ import {
   parseCampaignBoundaryMs,
   sumActiveCampaignBreakdownValues,
 } from '@/lib/campaignGroups';
-import { parseNumberInput } from '@/lib/numberFormat';
+import { parseSignedNumberInput } from '@/lib/numberFormat';
 import { resolveForecastTokenPrice } from '@/lib/tokenPriceResolver';
 import type {
   BrevisIncentive,
@@ -607,20 +607,35 @@ export const extractActionLabelFromMeritMessage = (message: IncentiveMessage): s
   return null;
 };
 
-export const buildMeritCampaignDetails = (
-  merits: MeritCampaignGroup[] | undefined,
-  isApy: boolean,
-  inputUsd: number,
-  hasAnyInput: boolean,
-  meritAnchorTvlUsd?: number,
+export interface MeritCampaignDetailsOptions {
+  merits: MeritCampaignGroup[] | undefined;
+  isApy: boolean;
+  inputUsd: number;
+  shouldComputeAfter: boolean;
+  meritAnchorTvlUsd?: number;
+  eligibilityRatio?: number;
+  grossInputUsd?: number;
+  totalPositionUsd?: number;
+  walletPositionUsd?: number;
+  grossForEligibility?: number;
+  netForEligibility?: number;
+  walletEligibilityRatio?: number;
+}
+
+export const buildMeritCampaignDetails = ({
+  merits,
+  isApy,
+  inputUsd,
+  shouldComputeAfter,
+  meritAnchorTvlUsd,
   eligibilityRatio = 1,
-  grossInputUsd?: number,
-  totalPositionUsd?: number,
-  walletPositionUsd?: number,
-  grossForEligibility?: number,
-  netForEligibility?: number,
+  grossInputUsd,
+  totalPositionUsd,
+  walletPositionUsd,
+  grossForEligibility,
+  netForEligibility,
   walletEligibilityRatio = 1,
-): SimulationCampaignDetail[] => {
+}: MeritCampaignDetailsOptions): SimulationCampaignDetail[] => {
   const rows: SimulationCampaignDetail[] = [];
   if (!merits?.length) return rows;
 
@@ -654,31 +669,29 @@ export const buildMeritCampaignDetails = (
       let capMetrics: import('./incentiveCaps').SimulationCapMetrics | undefined;
       let notes: import('./incentiveCaps').IncentiveNote[] | undefined;
 
-      if (inputUsd > 0) {
-        const fp = forecastMeritApr({
+      if (shouldComputeAfter) {
+        const fp = inputUsd > 0 ? forecastMeritApr({
           depositUsd: inputUsd,
           forecastAprPercent: baseAprPercent,
           startDate: breakdown.campaignStartedAt,
           endDate: breakdown.campaignEndedAt,
           anchorTvlUsd: meritAnchorTvlUsd,
-        });
-        if (fp) {
-          const fullAfter = meritForecastAprToDisplay(fp.apr, isApy);
-          if (positionCapUsd != null && positionCapUsd > 0) {
-            const capResult = applyPositionCapToForecastResult(
-              fullAfter,
-              totalPositionUsd ?? inputUsd,
-              positionCapUsd,
-              { },
-            );
-            baseAfter = capResult.aprPercent * eligibilityRatio;
-            capMetrics = capResult.capMetrics;
-            notes = capResult.notes;
-          } else {
-            baseAfter = fullAfter * eligibilityRatio;
-          }
+        }) : null;
+        const fullAfter = fp
+          ? meritForecastAprToDisplay(fp.apr, isApy)
+          : meritAprToDisplay(baseAprPercent, isApy);
+        if (positionCapUsd != null && positionCapUsd > 0) {
+          const capResult = applyPositionCapToForecastResult(
+            fullAfter,
+            totalPositionUsd ?? inputUsd,
+            positionCapUsd,
+            { },
+          );
+          baseAfter = capResult.aprPercent * eligibilityRatio;
+          capMetrics = capResult.capMetrics;
+          notes = capResult.notes;
         } else {
-          baseAfter = baseCurrent;
+          baseAfter = fullAfter * eligibilityRatio;
         }
       }
       const delta = baseAfter !== null ? baseAfter - baseCurrent : null;
@@ -698,29 +711,55 @@ export const buildMeritCampaignDetails = (
   return shouldExposeCampaignRows(rows) ? rows : [];
 };
 
-export const buildMerklCampaignDetails = (
-  opportunities: MerklOpportunityGroup[] | undefined,
-  isApy: boolean,
-  inputUsd: number,
-  forecastStates: Record<string, MerklForecastWireItem>,
-  whitelistMerklCampaignIds: ReadonlySet<string> | undefined,
-  tydroPointToUsdRate: number,
-  hasAnyInput: boolean,
+export interface MerklCampaignDetailsOptions {
+  opportunities: MerklOpportunityGroup[] | undefined;
+  isApy: boolean;
+  inputUsd: number;
+  forecastStates: Record<string, MerklForecastWireItem>;
+  whitelistMerklCampaignIds?: ReadonlySet<string>;
+  tydroPointToUsdRate: number;
+  shouldComputeAfter: boolean;
+  eligibilityRatio?: number;
+  grossInputUsd?: number;
+  merklGroupMultiplier?: (group: MerklOpportunityGroup) => number;
+  merklCrossReserveNote?: (group: MerklOpportunityGroup) => string | null;
+  campaignAccessStatuses?: Record<string, 'allowed' | 'whitelist-blocked' | 'blacklisted'>;
+  nativeApyPercent?: number;
+  pointRateMap?: PointRateMap;
+  grossForEligibility?: number;
+  netForEligibility?: number;
+  tokenPrice?: number;
+  decimals?: number;
+  tokenSymbol?: string;
+  walletEligibilityRatio?: number;
+  walletMerklGroupMultiplier?: (group: MerklOpportunityGroup) => number;
+  crossReserveNetEligibleUsd?: (group: MerklOpportunityGroup) => number;
+}
+
+export const buildMerklCampaignDetails = ({
+  opportunities,
+  isApy,
+  inputUsd,
+  forecastStates,
+  whitelistMerklCampaignIds,
+  tydroPointToUsdRate,
+  shouldComputeAfter,
   eligibilityRatio = 1,
-  grossInputUsd?: number,
-  merklGroupMultiplier?: (group: MerklOpportunityGroup) => number,
-  merklCrossReserveNote?: (group: MerklOpportunityGroup) => string | null,
-  campaignAccessStatuses?: Record<string, 'allowed' | 'whitelist-blocked' | 'blacklisted'>,
-  nativeApyPercent?: number,
-  pointRateMap?: PointRateMap,
-  grossForEligibility?: number,
-  netForEligibility?: number,
-  tokenPrice?: number,
-  decimals?: number,
-  tokenSymbol?: string,
+  grossInputUsd,
+  merklGroupMultiplier,
+  merklCrossReserveNote,
+  campaignAccessStatuses,
+  nativeApyPercent,
+  pointRateMap,
+  grossForEligibility,
+  netForEligibility,
+  tokenPrice,
+  decimals,
+  tokenSymbol,
   walletEligibilityRatio = 1,
-  walletMerklGroupMultiplier?: (group: MerklOpportunityGroup) => number,
-): SimulationCampaignDetail[] => {
+  walletMerklGroupMultiplier,
+  crossReserveNetEligibleUsd,
+}: MerklCampaignDetailsOptions): SimulationCampaignDetail[] => {
   if (!opportunities?.length) return [];
 
   const netNote = grossForEligibility != null && netForEligibility != null
@@ -751,11 +790,30 @@ export const buildMerklCampaignDetails = (
       const merged = mergeForecastState(bd, forecastStates, effectiveRate, nativeApyPercent);
       const forecastUnavailable = isForecastRequiring && checkForecastAvailability(bd.campaignType, bd.campaignId, merged, forecastStates);
 
-      if (inputUsd > 0) {
+      if (shouldComputeAfter) {
         const forecastApr = forecastMerklApr(bd, inputUsd, forecastStates, effectiveRate, nativeApyPercent);
         const forecastAprSan = sanitizePercent(forecastApr);
         const groupMul = merklGroupMultiplier ? merklGroupMultiplier(opportunity) : 1;
-        let afterValue = (isApy ? convertAprToApy(forecastAprSan) : forecastAprSan) * eligibilityRatio * groupMul;
+        const forecastRate = isApy ? convertAprToApy(forecastAprSan) : forecastAprSan;
+        const useUnifiedEligibility =
+          crossReserveNetEligibleUsd != null &&
+          grossForEligibility != null &&
+          grossForEligibility > 0;
+        const effectiveCapUsd = resolvePositionCapUsd(
+          bd.positionCapNative,
+          bd.positionCapUsd,
+          tokenPrice,
+          decimals,
+        );
+        const netEligibleUsd = useUnifiedEligibility
+          ? Math.max(crossReserveNetEligibleUsd(opportunity), 0)
+          : null;
+        const eligibleUsd = netEligibleUsd !== null && effectiveCapUsd != null && effectiveCapUsd > 0
+          ? Math.min(netEligibleUsd, effectiveCapUsd)
+          : netEligibleUsd;
+        let afterValue = useUnifiedEligibility
+          ? forecastRate * eligibleUsd! / grossForEligibility
+          : forecastRate * eligibilityRatio * groupMul;
 
         const merklType = merged?.campaignType;
         const isTargetTotalApr = merklType === 'TARGET_TOTAL_APR';
@@ -776,19 +834,27 @@ export const buildMerklCampaignDetails = (
           }
         }
 
-        const effectiveCapUsd = resolvePositionCapUsd(bd.positionCapNative, bd.positionCapUsd, tokenPrice, decimals);
         if (effectiveCapUsd != null && effectiveCapUsd > 0) {
-          const constraint = opportunity.netPositionConstraint;
-          const positionUsd = (constraint && netForEligibility != null && grossForEligibility != null && grossForEligibility > 0)
-            ? netForEligibility
-            : (grossInputUsd ?? inputUsd);
+          const positionUsd = useUnifiedEligibility
+            ? netEligibleUsd!
+            : (() => {
+                const constraint = opportunity.netPositionConstraint;
+                return constraint &&
+                  netForEligibility != null &&
+                  grossForEligibility != null &&
+                  grossForEligibility > 0
+                  ? netForEligibility
+                  : (grossInputUsd ?? inputUsd);
+              })();
           const capResult = applyPositionCapToForecastResult(
-            afterValue,
+            useUnifiedEligibility ? forecastRate : afterValue,
             positionUsd,
             effectiveCapUsd,
             { isCombineCap: bd.isCombineCap ?? false, positionCapNative: bd.positionCapNative, tokenSymbol, decimals },
           );
-          afterValue = capResult.aprPercent;
+          if (!useUnifiedEligibility) {
+            afterValue = capResult.aprPercent;
+          }
           if (capResult.notes) {
             capMetrics = capResult.capMetrics;
             notes = [...(notes ?? []), ...capResult.notes];
@@ -796,8 +862,6 @@ export const buildMerklCampaignDetails = (
         }
 
         after = afterValue;
-      } else if (hasAnyInput) {
-        after = null;
       }
 
       const delta = after !== null ? after - current : null;
@@ -821,16 +885,27 @@ export const buildMerklCampaignDetails = (
 };
 
 
-export const buildBrevisCampaignDetails = (
-  items: BrevisIncentive[] | undefined,
-  isApy: boolean,
-  inputUsd: number,
-  sharedDepositsByCampaignId: ReadonlyMap<string, number> | undefined,
-  hasAnyInput: boolean,
-  forecastStates: Record<string, MerklForecastWireItem> | undefined,
-  totalPositionUsd?: number,
-  walletPositionUsd?: number,
-): SimulationCampaignDetail[] => {
+export interface BrevisCampaignDetailsOptions {
+  items: BrevisIncentive[] | undefined;
+  isApy: boolean;
+  inputUsd: number;
+  sharedDepositsByCampaignId?: ReadonlyMap<string, number>;
+  shouldComputeAfter: boolean;
+  forecastStates?: Record<string, MerklForecastWireItem>;
+  totalPositionUsd?: number;
+  walletPositionUsd?: number;
+}
+
+export const buildBrevisCampaignDetails = ({
+  items,
+  isApy,
+  inputUsd,
+  sharedDepositsByCampaignId,
+  shouldComputeAfter,
+  forecastStates,
+  totalPositionUsd,
+  walletPositionUsd,
+}: BrevisCampaignDetailsOptions): SimulationCampaignDetail[] => {
   if (!items?.length) return [];
 
   const flattened = flattenBrevisCampaignRows(items);
@@ -852,19 +927,18 @@ export const buildBrevisCampaignDetails = (
     let capMetrics: import('./incentiveCaps').SimulationCapMetrics | undefined;
     let notes: import('./incentiveCaps').IncentiveNote[] | undefined;
     const combined = getBrevisCombinedDepositUsd(source, breakdown, sharedDepositsByCampaignId);
-    const effectiveInputUsd = combined ?? totalPositionUsd ?? inputUsd;
+    const positionUsd = combined ?? totalPositionUsd ?? inputUsd;
 
     const isForecastRequiring = !!resolved.campaignType && FORECAST_REQUIRING_CAMPAIGN_TYPES.has(resolved.campaignType);
     const forecastUnavailable = isForecastRequiring
       ? checkForecastAvailability(resolved.campaignType, resolved.campaignId, forecastStates ? mergeForecastState(resolved, forecastStates, 0) : undefined, forecastStates)
       : false;
 
-    if (effectiveInputUsd > 0) {
+    if (shouldComputeAfter && positionUsd > 0) {
       let aprPercent = forecastStates
-        ? sanitizePercent(forecastMerklApr(resolved, effectiveInputUsd, forecastStates, 0))
+        ? sanitizePercent(forecastMerklApr(resolved, inputUsd, forecastStates, 0))
         : nominal;
 
-      const positionUsd = effectiveInputUsd;
       const endMs = parseCampaignBoundaryMs(resolved.campaignEndedAt, 'end');
       const capResult = applyPositionCapToForecastResult(
         aprPercent,
@@ -886,8 +960,6 @@ export const buildBrevisCampaignDetails = (
         capMetrics = capResult.capMetrics;
         notes = capResult.notes;
       }
-    } else if (hasAnyInput) {
-      after = null;
     }
 
     const delta = after !== null ? after - current : null;
@@ -1031,16 +1103,16 @@ export function buildRateSimulationResult({
   pointRateMap,
   portfolioScenarioActive = false,
 }: BuildRateSimulationResultParams): RateSimulationComputedResult {
-  const rawSupply = parseNumberInput(supplyInput);
-  const rawBorrow = parseNumberInput(borrowInput);
+  const rawSupply = parseSignedNumberInput(supplyInput);
+  const rawBorrow = parseSignedNumberInput(borrowInput);
 
   // In USD mode, convert to token amounts for native simulation
   const supplyAmount = inputMode === 'usd' && tokenPrice ? rawSupply / tokenPrice : rawSupply;
   const borrowAmount = inputMode === 'usd' && tokenPrice ? rawBorrow / tokenPrice : rawBorrow;
   const supplyBlocked = isSupplyDisabled(reserve);
   const borrowBlocked = isBorrowDisabled(reserve);
-  const hasSupplyInput = supplyBlocked ? false : rawSupply > 0;
-  const hasBorrowInput = borrowBlocked ? false : rawBorrow > 0;
+  const hasSupplyInput = supplyBlocked ? false : rawSupply !== 0;
+  const hasBorrowInput = borrowBlocked ? false : rawBorrow !== 0;
   const hasAnyInput = hasSupplyInput || hasBorrowInput;
   // AAV-1166: Split hasAnyInput into hasLocalInput (unchanged behavior) and shouldComputeAfter.
   // portfolioScenarioActive opens after computation for portfolio members without local input.
@@ -1070,6 +1142,10 @@ export function buildRateSimulationResult({
     availableSupplyRoomUsd !== null && rawSupplyInputUsd > availableSupplyRoomUsd
       ? availableSupplyRoomUsd
       : rawSupplyInputUsd;
+  const liquiditySource = reserveRateInput ?? reserve;
+  const availableSupplyLiquidityUsd = tokenPrice && liquiditySource.liquidity
+    ? Number(liquiditySource.liquidity) / Math.pow(10, liquiditySource.decimals ?? DEFAULT_TOKEN_DECIMALS) * tokenPrice
+    : null;
 
   // Calculate current native simulation first to get totalBorrowedUsd for borrow cap
   const currentNativeSimulation = reserveRateInput
@@ -1097,8 +1173,11 @@ export function buildRateSimulationResult({
       : null;
 
   // If supply is disabled, new supply input does not increase available liquidity.
-  const effectiveSupplyInputUsd = supplyBlocked ? 0 : supplyInputUsd;
-  const liquiditySource = reserveRateInput ?? reserve;
+  const effectiveSupplyInputUsd = supplyBlocked
+    ? 0
+    : availableSupplyLiquidityUsd !== null
+      ? Math.max(supplyInputUsd, -availableSupplyLiquidityUsd)
+      : supplyInputUsd;
   const availableLiquidityForBorrowUsd = borrowBlocked ? null
     : liquiditySource.liquidity != null && tokenPrice
       ? (() => {
@@ -1337,7 +1416,8 @@ export function buildRateSimulationResult({
 
   interface SideSourceContext {
     isApy: boolean;
-    hasAnyInput: boolean;
+    shouldComputeAfter: boolean;
+    hasAnyScenarioInput: boolean;
     meritMerklInputUsd: number;
     grossInputUsd: number;
     eligibilityRatio: number;
@@ -1355,7 +1435,6 @@ export function buildRateSimulationResult({
     // When provided, cap and offset compose as single eligible principal in sumMerklIncentive*.
     crossReserveNetEligibleUsd: ((group: MerklOpportunityGroup) => number) | undefined;
     walletCrossReserveNetEligibleUsd: ((group: MerklOpportunityGroup) => number) | undefined;
-    merklCrossNote: ((group: MerklOpportunityGroup) => string | null) | undefined;
     campaignAccessStatuses: Record<string, 'allowed' | 'blacklisted' | 'whitelist-blocked'> | undefined;
     nativeApyPercent: number | undefined;
     brevisSharedDeposits: ReadonlyMap<string, number> | undefined;
@@ -1380,7 +1459,20 @@ export function buildRateSimulationResult({
         sumForecastMeritIncentiveApr(data, ctx.isApy, ctx.meritMerklInputUsd, ctx.anchorTvlUsd, ctx.totalPositionUsd)
         * ctx.eligibilityRatio,
       buildDetails: (data, ctx) =>
-        buildMeritCampaignDetails(data, ctx.isApy, ctx.meritMerklInputUsd, ctx.hasAnyInput, ctx.anchorTvlUsd, ctx.eligibilityRatio, ctx.grossInputUsd, ctx.totalPositionUsd, ctx.walletPositionUsd, ctx.grossForEligibility, ctx.netForEligibility, ctx.walletEligibilityRatio),
+        buildMeritCampaignDetails({
+          merits: data,
+          isApy: ctx.isApy,
+          inputUsd: ctx.meritMerklInputUsd,
+          shouldComputeAfter: ctx.shouldComputeAfter,
+          meritAnchorTvlUsd: ctx.anchorTvlUsd,
+          eligibilityRatio: ctx.eligibilityRatio,
+          grossInputUsd: ctx.grossInputUsd,
+          totalPositionUsd: ctx.totalPositionUsd,
+          walletPositionUsd: ctx.walletPositionUsd,
+          grossForEligibility: ctx.grossForEligibility,
+          netForEligibility: ctx.netForEligibility,
+          walletEligibilityRatio: ctx.walletEligibilityRatio,
+        }),
     },
     merkl: {
       // AAV-1164: Use crossReserveNetEligibleUsd for unified eligibility composition.
@@ -1400,7 +1492,29 @@ export function buildRateSimulationResult({
           : sumMerklIncentiveApr(forecasted, ctx.tydroPointToUsdRate, { whitelistMerklCampaignIds: ctx.whitelistMerklCampaignIds, campaignAccessStatuses: ctx.campaignAccessStatuses, crossReserveNetEligibleUsd: ctx.crossReserveNetEligibleUsd, merklGroupMultiplier: ctx.merklGroupMul, pointRateMap: ctx.pointRateMap, positionUsd: ctx.totalPositionUsd, tokenPrice: ctx.tokenPrice, decimals: ctx.decimals });
       },
       buildDetails: (data, ctx) =>
-        buildMerklCampaignDetails(data, ctx.isApy, ctx.meritMerklInputUsd, ctx.forecastStates!, ctx.whitelistMerklCampaignIds, ctx.tydroPointToUsdRate, ctx.hasAnyInput, ctx.eligibilityRatio, ctx.grossInputUsd, ctx.merklGroupMul, ctx.merklCrossNote, ctx.campaignAccessStatuses, ctx.nativeApyPercent, ctx.pointRateMap, ctx.grossForEligibility, ctx.netForEligibility, ctx.tokenPrice, ctx.decimals, ctx.tokenSymbol, ctx.walletEligibilityRatio, ctx.walletMerklGroupMul),
+        buildMerklCampaignDetails({
+          opportunities: data,
+          isApy: ctx.isApy,
+          inputUsd: ctx.meritMerklInputUsd,
+          forecastStates: ctx.forecastStates ?? {},
+          whitelistMerklCampaignIds: ctx.whitelistMerklCampaignIds,
+          tydroPointToUsdRate: ctx.tydroPointToUsdRate,
+          shouldComputeAfter: ctx.shouldComputeAfter,
+          eligibilityRatio: ctx.eligibilityRatio,
+          grossInputUsd: ctx.grossInputUsd,
+          merklGroupMultiplier: ctx.merklGroupMul,
+          campaignAccessStatuses: ctx.campaignAccessStatuses,
+          nativeApyPercent: ctx.nativeApyPercent,
+          pointRateMap: ctx.pointRateMap,
+          grossForEligibility: ctx.grossForEligibility,
+          netForEligibility: ctx.netForEligibility,
+          tokenPrice: ctx.tokenPrice,
+          decimals: ctx.decimals,
+          tokenSymbol: ctx.tokenSymbol,
+          walletEligibilityRatio: ctx.walletEligibilityRatio,
+          walletMerklGroupMultiplier: ctx.walletMerklGroupMul,
+          crossReserveNetEligibleUsd: ctx.crossReserveNetEligibleUsd,
+        }),
     },
     brevis: {
       // AAV-1102: sumCurrent must apply wallet position cap dilution to match per-campaign current
@@ -1408,7 +1522,16 @@ export function buildRateSimulationResult({
       sumAfter: (data, ctx) =>
         sumForecastBrevisIncentiveApr(data, ctx.isApy, ctx.grossInputUsd, ctx.brevisSharedDeposits, ctx.forecastStates, ctx.totalPositionUsd),
       buildDetails: (data, ctx) =>
-        buildBrevisCampaignDetails(data, ctx.isApy, ctx.grossInputUsd, ctx.brevisSharedDeposits, ctx.hasAnyInput, ctx.forecastStates, ctx.totalPositionUsd, ctx.walletPositionUsd),
+        buildBrevisCampaignDetails({
+          items: data,
+          isApy: ctx.isApy,
+          inputUsd: ctx.grossInputUsd,
+          sharedDepositsByCampaignId: ctx.brevisSharedDeposits,
+          shouldComputeAfter: ctx.hasAnyScenarioInput,
+          forecastStates: ctx.forecastStates,
+          totalPositionUsd: ctx.totalPositionUsd,
+          walletPositionUsd: ctx.walletPositionUsd,
+        }),
     },
   };
 
@@ -1426,7 +1549,8 @@ export function buildRateSimulationResult({
 
     const ctx: SideSourceContext = {
       isApy,
-      hasAnyInput,
+      shouldComputeAfter: sideHasInput || portfolioScenarioActive,
+      hasAnyScenarioInput: hasAnyInput || portfolioScenarioActive,
       meritMerklInputUsd: isSupply ? supplyMeritMerklInputUsd : borrowMeritMerklInputUsd,
       grossInputUsd: isSupply ? supplyInputUsd : borrowInputUsd,
       eligibilityRatio: isSupply ? supplyMeritMerklEligibilityRatio : borrowMeritMerklEligibilityRatio,
@@ -1442,7 +1566,6 @@ export function buildRateSimulationResult({
       walletMerklGroupMul: walletMerklGroupMultiplier(side),
       crossReserveNetEligibleUsd: crossReserveNetEligibleUsdFn(side),
       walletCrossReserveNetEligibleUsd: walletCrossReserveNetEligibleUsdFn(side),
-      merklCrossNote: merklCrossReserveNote(side),
       campaignAccessStatuses,
       nativeApyPercent: isSupply ? (reserve.supplyApy ?? 0) : (reserve.borrowApy ?? 0),
       brevisSharedDeposits: brevisSharedDepositsByCampaignId,

--- a/src/test/ci-openapi-workflow-guard.test.ts
+++ b/src/test/ci-openapi-workflow-guard.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const WORKFLOW_PATH = resolve(__dirname, '..', '..', '.github', 'workflows', 'ci.yml');
+
+function getJobBlock(workflow: string, jobName: string): string {
+  const start = workflow.indexOf(`  ${jobName}:\n`);
+  const remainder = workflow.slice(start + 1);
+  const nextJob = remainder.search(/\n {2}[A-Za-z0-9_-]+:\n/);
+  return workflow.slice(start, nextJob === -1 ? undefined : start + 1 + nextJob);
+}
+
+function getLiveApiBase(jobBlock: string): string | undefined {
+  return jobBlock.match(/LIVE_API_BASE:\s*(.+)/)?.[1]?.trim();
+}
+
+describe('OpenAPI CI workflow guard', () => {
+  it('checks and syncs the OpenAPI spec against the same backend', () => {
+    const workflow = readFileSync(WORKFLOW_PATH, 'utf8');
+    const checkApiBase = getLiveApiBase(getJobBlock(workflow, 'openapi-check'));
+    const syncApiBase = getLiveApiBase(getJobBlock(workflow, 'openapi-sync'));
+
+    expect(checkApiBase).toBe(
+      "${{ secrets.LIVE_TEST_API_BASE_CI || 'https://staging-api.aaveapy.com/api' }}",
+    );
+    expect(syncApiBase).toBe(checkApiBase);
+  });
+});


### PR DESCRIPTION
## Summary

Remediates formal review findings on PR #430 Codex fixes:

- **Campaign detail typed context**: Converted `buildMeritCampaignDetails`, `buildMerklCampaignDetails`, and `buildBrevisCampaignDetails` from positional parameters to typed options objects, preventing argument-order defects.
- **Portfolio campaign after-values**: Campaign detail rows now compute after values for signed withdrawals and unchanged portfolio members, reconciling with source totals via `shouldComputeAfter` gating.
- **Withdrawal liquidity clamp**: Negative supply deltas are clamped to executable reserve liquidity before entering the native rate model.
- **Desktop E2E project filtering**: Replaced runtime `test.skip(mobile)` with `testIgnore` in Playwright config per AGENTS.md E2E policy.
- **Deterministic pin regression**: Pin test now asserts `observedPin === true` after the scenario loop, preventing false passes without exercising the pin path.
- **OpenAPI CI consistency**: Aligned `openapi-sync` to `secrets.LIVE_TEST_API_BASE_CI` matching the `openapi-check` job.
- **Signed number parsing**: Added `parseSignedNumberInput` and signed bigint unit parsing for withdrawal scenario activation.

## Linear

- Parent: AAV-1171
- AAV-1174: Type campaign detail calculation context
- AAV-1172: Reconcile campaign after values in portfolio scenarios
- AAV-1173: Require desktop scenario pin regression path

## Validation

- lint + test + build + tsc: all green
- 3/3 Chromium Playwright simulation tests passed