### PR TITLE
Sync lovable → dev (touch target optimization)

### DIFF
--- a/docs/design/DESIGN-SYSTEM-REFERENCE.md
+++ b/docs/design/DESIGN-SYSTEM-REFERENCE.md
@@ -169,7 +169,7 @@
 
 ## 4. 布局原则
 
-- **移动优先**，触控目标 ≥ 44×44px。
+- **移动优先**，触控目标 ≥ 44×44px。**视觉尺寸可以小于 44px**——通过 `min-h/w-[44px]` 透明 padding（模式 A）、外层容器补足（模式 B）、或 `::before` 伪元素扩展（模式 C）使触控热区达到 44px。详见 `docs/design/mobile-touch-target-optimization.md`。
 - **多列面板**（如 Supply / Spread / Borrow）：等宽列、统一压缩，不单独给某一列固定或更大宽度。
 - **表格**：表头与占位符（如 `-`）使用相同列宽与对齐，避免表头与内容错位。**所有表格内容统一遵循\"优先保持单行，仅在确实放不下时换行\"**——既不\"优先换行\"也不\"省略\"，token symbol、市场名、价格、APY 等都按这条规则处理。换行通过 `break-words` + `min-w-0` 实现，**禁止**使用 `truncate` / 尾部省略号或 `break-all`。
 - **相邻列最小可见 gap（强制，跨场景通用）**：任何\"多列\"布局——不仅是 `<table>`，也包括 grid、多列卡片、并排面板——**相邻列之间必须保留固定的最小可见间距**，让相邻列的文字、数字、尾部图标不会在窄视口下读起来像粘成一团或互相覆盖。最小值建议 **≥ `--ds-space-2` (8 px)**；当某一列以尾部图标（外链 `↗`、菜单触发器、chevron 等）结束、邻列以紧凑数字/价格开头时，**总间距 ≥ 10 px**（典型实现：`pr-[var(--ds-space-2)]` + `pl-[var(--ds-space-1-5)]`，或者用一个统一的列间 `column-gap`/`gap` 变量）。该最小值在 header / body / skeleton 必须**保持一致**；只增不减——不允许在某一行类型把它降到下限以下。落到具体表格的执行细则见 §4.1。
@@ -716,7 +716,10 @@ const after = disabled ? null : simulation.after;
 
 ## 9. 移动端与触控
 
-- **触控目标**：最小 44×44px（包括可点击的“Simulation ⌄”等）。
+- **触控目标**：最小 44×44px（包括可点击的“Simulation ⌄”等）。**视觉 ≠ 触控**：视觉元素可小于 44px（28-36px），触控热区通过 padding、外层容器、或 `::before` 伪元素补足。三种模式：
+  - **模式 A**：按钮 `min-h/w-[44px]` + 透明 padding，图标居中（图标按钮）
+  - **模式 B**：外层容器 `py-1` 等补足到 44px（输入框、tab 行）
+  - **模式 C**：`::before` 伪元素 `inset: -Npx` 向外扩展（chip、switch——不能用 `min-h` 否则改变视觉高度）
 - **浮层**：移动端详情类内容用**底部抽屉（bottom sheet）**：全宽、`rounded-t-2xl`、固定标题+关闭、内容区 `max-h-[80vh] overflow-y-auto`，背景 `fixed inset-0 z-30 bg-background/40` 点击关闭。间距全面紧凑：标题栏 `px-[var(--ds-space-2)] py-[var(--ds-space-1-5)]`，内容区 `px-[var(--ds-space-3)] pt-[var(--ds-space-2)] pb-[var(--ds-space-2)]`，内部行间距统一 `space-y-1`（移动端弹窗遮挡底层内容多，收紧垂直空间最大化可见表格区域）。动画使用 Framer Motion `AnimatePresence`：背景 opacity 0→1，面板 y: 100%→0、duration 0.28s。MobileReserveCard 的 cap/deficit/utilization/frozen 抽屉内联在组件内（`MobileCapSheet`），其他场景可用共享组件 `src/components/dashboard/BottomSheet.tsx`。不在移动端用小浮层 popover 锚定在触发点上。
 - **轮播**：移动端轮播需包含：分页点、左右箭头（在可滚动时显示）、peek（如 `basis-[85%]`）、`align: "center"` + `containScroll: "trimSnaps"`。
 - **避免**：仅在 hover 上做交互，移动端需提供 tap/click 等价操作。

--- a/docs/design/mobile-touch-target-optimization.md
+++ b/docs/design/mobile-touch-target-optimization.md
@@ -1,0 +1,354 @@
+# Mobile Touch Target Optimization — Portfolio Simulation
+
+> **Status**: Draft — 待审核
+> **Date**: 2026-07-18
+> **Scope**: 移动端 Portfolio Simulation 所有交互元素的触控目标与视觉尺寸优化
+> **Motivation**: 当前部分元素刚好 44px 但视觉偏大（视觉=触控无分离），部分元素远低于 44px（不达标）。需要统一方案：视觉缩小 + 触控热区保持 44px。
+
+---
+
+## 1. 现状分析
+
+### 1.1 达标元素（44px，但视觉=触控无分离）
+
+| # | 元素 | 文件:行 | 当前尺寸 | 视觉感受 |
+|---|------|---------|----------|----------|
+| 1 | Minus/EyeOff 移除按钮 | `MobilePortfolioCard.tsx:214` | `min-h-[44px] min-w-[44px]` + `p-1.5` + icon `size-3.5`(14px) | OK — 图标小，视觉不显大 |
+| 2 | Supply/Borrow Tab | `MobilePortfolioCard.tsx:248` | `min-h-[44px]` + `flex-1` | 偏大 — 44px 高度的文字 tab 在紧凑面板里占地 |
+| 3 | $/T 切换按钮 | `PortfolioTablePrimitives.tsx:352` | `h-11 w-11` (44×44) | 偏大 — 方形按钮视觉冲击强 |
+| 4 | Input 输入框 | `PortfolioTablePrimitives.tsx:387` | `h-11` (44px) | 偏大 — 输入框 44px 高在密集数据面板里偏厚 |
+| 5 | 清除按钮 (Eraser) | `PortfolioTablePrimitives.tsx:397` | `min-h-[44px] min-w-[44px]` + `p-2` + icon `size-4`(16px) | OK — 图标小 |
+| 6 | Daily Earnings 展开按钮 | `MobilePortfolioCard.tsx:335` | `min-h-[44px]` + `w-full` | OK — 全宽按钮视觉合理 |
+
+### 1.2 不达标元素（<44px）
+
+| # | 元素 | 文件:行 | 当前尺寸 | 差距 |
+|---|------|---------|----------|------|
+| 7 | SegmentedToggle 垂直模式 segment | `segmented-toggle.tsx:154` | 28px 高 (`min-h-[var(--ds-seg-seg-min-h)]`) | **-16px** |
+| 8 | ScenarioControls 移动端 Input | `ScenarioControls.tsx:273` | 36px 高 (`h-[var(--ds-button-sm-h)]`) | **-8px** |
+| 9 | SlidersHorizontal 按钮 | `ScenarioControls.tsx:304` | 32×32 (`h-[var(--ds-control-h)] w-[var(--ds-control-h)]`) | **-12px** |
+| 10 | PortfolioPanel Header 图标按钮 | `PortfolioPanel.tsx` (via `headerControlStyles.ts:56`) | 32×32 (`w-[var(--ds-control-h)] h-[var(--ds-control-h)]`) | **-12px** |
+| 11 | 搜索 Input | `PortfolioPanel.tsx` | 32px 高 (`h-[var(--ds-control-h)]`) | **-12px** |
+| 12 | PopularTokenChip | `PortfolioPanel.tsx` | 28px 高 (`h-[var(--ds-chip-h)]`) | **-16px** |
+| 13 | PortfolioModeToggle Switch | `PortfolioPanel.tsx` | 20×36px (`h-5 w-9`) | **-24px** |
+
+---
+
+## 2. 核心策略：视觉小 + 触控热区大
+
+### 2.1 原则
+
+触控目标 44px 是 Apple HIG / WCAG 2.5.8 推荐下限，交互元素**不能低于此**。但 **视觉尺寸 ≠ 触控尺寸**：
+
+- 视觉元素（图标、文字、输入框边框）可以更小（28-36px）
+- 触控热区通过 `min-h/w-[44px]`、`p-2` padding、或 `::before` 伪元素补足到 44px
+- 用户看不到触控热区，只感受到"点得准"
+
+### 2.2 实现模式
+
+**模式 A — `min-h/w-[44px]` + 透明 padding**
+
+适用于：图标按钮等视觉元素明显小于 44px 的场景。按钮本身透明 padding 撑到 44px，图标居中。
+
+```tsx
+// 32px 视觉按钮，44px 触控热区
+<button className="min-h-[44px] min-w-[44px] p-2 ...">
+  <Icon className="size-4" />
+</button>
+```
+
+**模式 B — 外层容器补足**
+
+适用于：输入框、tab 行等视觉高度需要降低，但触控高度通过父容器 padding 补足。视觉元素高度不变，外层容器补 padding 使总高度达到 44px。
+
+```tsx
+// 36px 视觉输入框，外层 4px padding 补足到 44px
+<div className="py-1"> {/* 4px×2 = 8px 补足 */}
+  <input className="h-9 ..." /> {/* 36px */}
+</div>
+// 总行高 = 36 + 8 = 44px
+```
+
+**模式 C — `::before` 伪元素扩展**
+
+适用于：视觉尺寸固定且不能用 `min-h` 改变的元素（如 chip、switch）。`min-h-[44px]` 会改变元素视觉高度，因此用伪元素向外扩展触控热区，不改变元素本身尺寸。
+
+```tsx
+// 28px 视觉 chip，44px 触控热区（不改变 chip 高度）
+<button className="relative h-[var(--ds-chip-h)] touch-target-expand ...">
+  ...
+</button>
+```
+```css
+.touch-target-expand::before {
+  content: '';
+  position: absolute;
+  inset: -8px; /* 向四周扩展 */
+  z-index: -1; /* 不遮挡相邻元素 */
+}
+```
+
+---
+
+## 3. 逐元素方案
+
+### 3.1 达标元素优化（降视觉尺寸，保留触控热区）
+
+#### E3: $/T 切换按钮（模式 A）
+
+| 属性 | 当前 | 优化后 |
+|------|------|--------|
+| 视觉高度 | `h-11` (44px) | `h-9` (36px) |
+| 视觉宽度 | `w-11` (44px) | `w-9` (36px) |
+| 触控高度 | 44px | `min-h-[44px]` (44px) |
+| 触控宽度 | 44px | `min-w-[44px]` (44px) |
+| 图标/文字 | `ds-text-9` | 不变 |
+| 桌面端 | `md:h-5 md:w-auto` | 不变 |
+
+代码变更：
+```diff
+- 'h-11 w-11 px-1 md:h-5 md:w-auto md:px-1',
++ 'h-9 w-9 px-1 min-h-[44px] min-w-[44px] md:h-5 md:w-auto md:px-1 md:min-h-0 md:min-w-0',
+```
+
+#### E4: Input 输入框（模式 B）
+
+| 属性 | 当前 | 优化后 |
+|------|------|--------|
+| 视觉高度 | `h-11` (44px) | `h-9` (36px) |
+| 触控高度 | 44px | 通过外层 `py-1`(4px×2) 补足 → 44px |
+| 行总高 | 44px | 44px（**不变**） |
+| 桌面端 | `md:h-5` | 不变 |
+
+代码变更（在 CompactInput 的外层容器）：
+```diff
+  // PortfolioTablePrimitives.tsx — CompactInput return
+- <div className="flex items-center gap-1 md:gap-0.5">
++ <div className="flex items-center gap-1 md:gap-0.5 py-1 md:py-0">
+    ...
+-   'h-11 md:h-5 w-full ...',
++   'h-9 md:h-5 w-full ...',
+```
+
+#### E2: Supply/Borrow Tab（模式 C）
+
+| 属性 | 当前 | 优化后 |
+|------|------|--------|
+| 视觉高度 | `min-h-[44px]` | `min-h-[36px]` |
+| 触控高度 | 44px (button) | 通过按钮 `::before` 伪元素扩展（不改容器 padding） |
+| 字号 | `ds-text-12` | 不变 |
+| 行总高 | ~48px (44+2+2) | ~40px (36+2+2) — **行 -8px** |
+
+代码变更：
+```diff
+  // MobilePortfolioCard.tsx — tab button (not container)
+- '... min-h-[44px]',
++ '... min-h-[36px] relative touch-target-expand',
+```
+```css
+/* 在 tab button 上用 ::before 上下扩展触控热区 */
+.touch-target-expand::before {
+  content: '';
+  position: absolute;
+  inset: -4px -2px; /* 上下扩展 4px → 36+4+4=44px */
+  z-index: -1;
+}
+```
+
+> **注意**：不用在 tablist 容器上加 `pt-2 pb-2`。那会使行总高从 48px 增到 52px（反而更高）。用 `::before` 扩展触控热区不改变布局高度。
+
+#### E5: 清除按钮 (Eraser)（无需变更）
+
+| 属性 | 当前 | 优化后 |
+|------|------|--------|
+| 视觉 | `min-h/w-[44px]` + `p-2` + icon 16px | 不变 — 图标已足够小 |
+| 触控 | 44px | 不变 |
+
+#### E1: Minus/EyeOff 按钮（无需变更）
+
+| 属性 | 当前 | 优化后 |
+|------|------|--------|
+| 视觉 | `min-h/w-[44px]` + `p-1.5` + icon 14px | 不变 — 图标已足够小 |
+| 触控 | 44px | 不变 |
+
+#### E6: Daily Earnings 展开按钮（无需变更）
+
+| 属性 | 当前 | 优化后 |
+|------|------|--------|
+| 视觉 | `min-h-[44px]` + `w-full` | 不变 — 全宽按钮视觉合理 |
+| 触控 | 44px | 不变 |
+
+---
+
+### 3.2 不达标元素修复（补触控热区）
+
+#### E7: SegmentedToggle 垂直模式（模式 B — 调用方补足）
+
+| 属性 | 当前 | 优化后 |
+|------|------|--------|
+| Segment 视觉高度 | 28px (`min-h-[var(--ds-seg-seg-min-h)]`) | 不变 |
+| Track padding | `p-[var(--ds-seg-track-pad)]` = 3px | 不变 |
+| 整体触控高度 | ~34px (28+3+3) | 通过调用方外层容器补足 |
+
+代码变更（在 `ScenarioControls.tsx` 的调用处，不改 `segmented-toggle.tsx` 组件本身）：
+```diff
+  // ScenarioControls.tsx — SegmentedToggle 外层
+- <SegmentedToggle ... className="shrink-0 self-stretch" />
++ <div className="py-2 md:py-0"> {/* 8px×2 补足到 ~50px */}
++   <SegmentedToggle ... className="shrink-0 self-stretch" />
++ </div>
+```
+
+> **范围注意**：不改 `segmented-toggle.tsx` 组件本身，避免影响其他使用方（如 Header 等）。仅在 ScenarioControls 调用处加外层 padding。
+
+#### E8: ScenarioControls 移动端 Input（模式 B）
+
+| 属性 | 当前 | 优化后 |
+|------|------|--------|
+| 视觉高度 | 36px (`h-[var(--ds-button-sm-h)]`) | 不变 |
+| 触控高度 | 36px | 通过外层容器 `py-1`(4px×2) 补足 → 44px |
+
+代码变更（`ScenarioControls.tsx`）：
+```diff
+  // 两个 ScenarioInputField 的外层 flex-col
+- <div className="flex flex-col gap-1 flex-1 min-w-0">
++ <div className="flex flex-col gap-0.5 flex-1 min-w-0 py-1">
+```
+注意：gap 从 1(4px) 缩到 0.5(2px) 以补偿 py-1 增加的总高度。
+
+#### E9: SlidersHorizontal 按钮（模式 A）
+
+| 属性 | 当前 | 优化后 |
+|------|------|--------|
+| 视觉 | 32×32 + icon `size-3.5`(14px) | 不变 |
+| 触控 | 32×32 | `min-h-[44px] min-w-[44px]` + 居中 |
+
+代码变更（`ScenarioControls.tsx:304`）：
+```diff
+- 'shrink-0 inline-flex h-[var(--ds-control-h)] w-[var(--ds-control-h)] items-center justify-center ...',
++ 'shrink-0 inline-flex h-[var(--ds-control-h)] w-[var(--ds-control-h)] min-h-[44px] min-w-[44px] items-center justify-center ...',
+```
+
+#### E10: PortfolioPanel Header 图标按钮（模式 A — 调用方补足）
+
+| 属性 | 当前 | 优化后 |
+|------|------|--------|
+| 视觉 | 32×32 | 不变 |
+| 触控 | 32×32 | 在 PortfolioPanel 调用处加 `min-h-[44px] min-w-[44px]` |
+
+代码变更（在 `PortfolioPanel.tsx` 的按钮 className 上，不改 `headerControlStyles.ts` 全局常量）：
+```diff
+  // PortfolioPanel.tsx — 每个图标按钮
+  className={cn(
+    HEADER_CONTROL_ICON_BUTTON_CLASS,
++   'min-h-[44px] min-w-[44px] md:min-h-0 md:min-w-0',
+    ...
+  )}
+```
+
+> **范围注意**：不改 `headerControlStyles.ts`，避免影响 `Header.tsx`、`WatchAddressInput.tsx`、`WalletButton.tsx` 等全站组件。仅在 PortfolioPanel 的调用处加。
+
+#### E11: 搜索 Input（模式 B — 外层容器补足）
+
+| 属性 | 当前 | 优化后 |
+|------|------|--------|
+| 视觉高度 | 32px (`h-[var(--ds-control-h)]`) | 不变 |
+| 触控高度 | 32px | 通过外层容器 `py-1`(4px×2) 补足 → 44px |
+
+代码变更（在搜索 Input 外层加 padding，不在 input 上加 `min-h`）：
+```diff
+  // PortfolioPanel.tsx — 搜索 input 外层
+- <div className="...">
++ <div className="... py-1 md:py-0">
+    ...
+    className="h-[var(--ds-control-h)] w-full ..."
+    // 不加 min-h-[44px] — 那会使 input 视觉变 44px
+```
+
+> **修正说明**：原方案在 input 上加 `min-h-[44px]` 会使 input 视觉高度变成 44px，违背"视觉小"策略。改用模式 B。
+
+#### E12: PopularTokenChip（模式 C — `::before` 伪元素扩展）
+
+| 属性 | 当前 | 优化后 |
+|------|------|--------|
+| 视觉高度 | 28px (`h-[var(--ds-chip-h)]`) | 不变 |
+| 触控高度 | 28px | 通过 `::before` 伪元素上下扩展 8px → 44px |
+
+代码变更：
+```diff
+- className="inline-flex h-[var(--ds-chip-h)] ..."
++ className="inline-flex h-[var(--ds-chip-h)] relative touch-target-expand ..."
+```
+
+> **修正说明**：原方案用 `min-h-[44px]` 会使 chip 视觉变 44px，违背"视觉小"策略。改用模式 C（`::before`），chip 高度保持 28px，触控热区扩展到 44px。
+
+#### E13: PortfolioModeToggle Switch（模式 C — 外层容器）
+
+| 属性 | 当前 | 优化后 |
+|------|------|--------|
+| 视觉 | 20×36px (原生 Switch) | 不变 |
+| 触控 | 20×36px | 外层容器 `min-h-[44px] min-w-[44px]` + 居中 |
+
+代码变更：
+```diff
+  // Switch 外层容器
+- <div className="...">
++ <div className="... min-h-[44px] min-w-[44px] flex items-center justify-center">
+```
+
+**Switch 特例说明**：原生 Switch 控件在各平台都是 20-36px 高度，用户已形成肌肉记忆。强行把 Switch 本身撑到 44px 反而违和。正确做法是保持 Switch 原生尺寸，扩大可点击容器。
+
+---
+
+## 4. 预期效果
+
+### 4.1 视觉紧凑度
+
+| 区域 | 当前行高 | 优化后行高 | 变化 |
+|------|----------|-----------|------|
+| Tab 行 | ~48px (44+2+2) | ~40px (36+2+2) | **行 -8px** |
+| CompactInput 行 | 44px | 44px (36+4+4) | **行不变**（视觉 -8px） |
+| 单个 card 估算 | ~250px | ~242px | **-8px** |
+
+> **修正说明**：原方案声称 Tab 行和 Input 行各节省 8px、card 共节省 20px。实际：Tab 行 -8px（`::before` 不占布局高度），Input 行不变（padding 补偿了视觉缩小），card 共 -8px。
+
+### 4.2 触控可达性
+
+- 所有 13 个交互元素均达到 44px 触控目标
+- 视觉尺寸降低后卡片更紧凑，同一屏幕可容纳更多 token
+- 无障碍合规（WCAG 2.5.8 / Apple HIG）
+
+---
+
+## 5. 待确认事项
+
+以下问题需要审核者拍板：
+
+1. **Input 高度**：从 44px 降到 36px（`h-9`），11px 字号在 36px 输入框内是否舒适？备选：`h-10`(40px) 折中。
+2. **Tab 高度**：从 44px 降到 36px，12px 字号在 36px tab 内是否太扁？备选：38px（`h-[38px]`）。
+3. **PopularTokenChip**：28px 视觉 + `::before` 扩展，相邻 chip 之间的 `::before` 会不会重叠？是否需要给 chip container 加 gap？
+4. **Switch 特例**：是否认可"保持原生尺寸 + 扩大容器"方案，还是希望 Switch 本身也要 44px？
+5. **`touch-target-expand` CSS class**：是放在全局 `index.css` 还是组件级？建议全局，供多处复用。
+
+---
+
+## 6. 不在本方案范围内
+
+- 桌面端尺寸调整（桌面端不需要 44px 触控目标）
+- 展开区域（Detail section）内的非交互展示元素
+- Metrics 三列网格（非交互，不受 44px 限制）
+- 卡片间距、圆角等布局微调（属于 `layout` 命令范畴）
+- `headerControlStyles.ts` 全局常量修改（仅改 PortfolioPanel 调用处）
+- `segmented-toggle.tsx` 组件本身修改（仅改 ScenarioControls 调用处）
+
+---
+
+## 7. 参考依据
+
+- Apple Human Interface Guidelines: 44×44pt minimum touch target
+- WCAG 2.5.8 (Target Size Minimum): 24px minimum (AA), 44px recommended (AAA)
+- Material Design: 48×48dp touch target
+- Impeccable skill `reference/layout.md`: "Touch targets must be 44×44px minimum even when the visual element is smaller. Expand the hit area with padding or a pseudo-element."
+- 项目 `DESIGN-SYSTEM-REFERENCE.md` §172/719/792: 触控目标 ≥44px
+- 项目 `docs/design/mobile-portfolio-audit-2026-07.md`: 审计发现 4/6 元素不达标
+- 项目 `docs/design/mobile-portfolio-simulation.md`: 原始移动端设计文档

--- a/docs/specs/mobile-touch-target-optimization.md
+++ b/docs/specs/mobile-touch-target-optimization.md
@@ -1,0 +1,92 @@
+# Spec: Mobile Touch Target Optimization
+
+**来源**: `docs/design/mobile-touch-target-optimization.md` (设计文档)
+**日期**: 2026-07-18
+**Linear Issue**: AAV-12XX (pending)
+
+---
+
+## Problem Statement
+
+移动端 Portfolio Simulation 有 7 个交互元素触控目标低于 44px（WCAG 2.5.8 / Apple HIG 不达标），4 个元素刚好 44px 但视觉偏大（视觉=触控无分离）。用户难以准确触摸，且紧凑数据面板视觉密度不够。
+
+## Solution
+
+采用"视觉小 + 触控热区大"策略：视觉元素保持 28-36px，触控热区通过三种模式补足到 44px。所有共享组件的改动仅在调用方进行，不改全局常量，避免影响全站。
+
+## User Stories
+
+1. 作为移动端用户，我希望所有可点击元素都 ≥44px 触控热区，以便准确触摸
+2. 作为移动端用户，我希望视觉元素紧凑（28-36px），以便同一屏幕看到更多 token
+3. 作为移动端用户，我希望输入框视觉更薄（36px），以便数据面板不显得厚重
+4. 作为移动端用户，我希望 tab 视觉更矮（36px），以便紧凑面板里占地少
+5. 作为无障碍用户，我希望所有交互元素满足 WCAG 2.5.8，以便合规使用
+
+## Implementation Decisions
+
+### ID-1: `touch-target-expand` 全局 CSS 工具类
+- 在 `index.css` 添加 `.touch-target-expand::before` 工具类
+- `content: ''; position: absolute; inset: -8px; pointer-events: auto;`
+- 供 E2 Tab、E12 Chip 等使用模式 C 的元素复用
+
+### ID-2: E3 $/T 切换 — 视觉 36px + 触控 44px（模式 A）
+- `h-11 w-11` → `h-9 w-9 min-h-[44px] min-w-[44px] md:h-5 md:w-auto md:min-h-0 md:min-w-0`
+
+### ID-3: E4 Input — 视觉 36px + 外层 py-1 补足（模式 B）
+- `h-11` → `h-9`，外层 `<div>` 加 `py-1 md:py-0`
+- 行总高不变（44px）
+
+### ID-4: E2 Tab — 视觉 36px + `::before` 扩展（模式 C）
+- `min-h-[44px]` → `min-h-[36px] relative touch-target-expand`
+- 不在容器加 `pt-2 pb-2`（那会使行更高）
+- 行总高 -8px
+
+### ID-5: E7 SegmentedToggle — 调用方外层 py-2（模式 B）
+- 在 `ScenarioControls.tsx` 调用处加 `<div className="py-2 md:py-0">`
+- 不改 `segmented-toggle.tsx` 组件本身
+
+### ID-6: E8 ScenarioControls Input — 外层 py-1（模式 B）
+- `<div className="flex flex-col gap-1 ...">` → `gap-0.5 ... py-1`
+
+### ID-7: E9 SlidersHorizontal — min-h/w-[44px]（模式 A）
+- 在按钮 className 加 `min-h-[44px] min-w-[44px]`
+
+### ID-8: E10 Header 图标 — 调用方加 min-h（模式 A）
+- 在 `PortfolioPanel.tsx` 每个图标按钮加 `min-h-[44px] min-w-[44px] md:min-h-0 md:min-w-0`
+- 不改 `headerControlStyles.ts` 全局常量
+
+### ID-9: E11 搜索 Input — 外层 py-1（模式 B）
+- 搜索 Input 外层 `<div>` 加 `py-1 md:py-0`
+- 不在 input 上加 `min-h`（那会使 input 视觉变 44px）
+
+### ID-10: E12 PopularTokenChip — `::before` 扩展（模式 C）
+- chip 加 `relative touch-target-expand`
+- chip 高度保持 28px，不用 `min-h`
+
+### ID-11: E13 Switch — 外层容器 min-h（模式 C 变体）
+- Switch 外层 `<div>` 加 `min-h-[44px] min-w-[44px] flex items-center justify-center`
+- Switch 本身保持原生尺寸
+
+### ID-12: E1/E5/E6 — 无需变更
+- 移除按钮、清除按钮、展开按钮已达标且视觉合理
+
+## Testing Decisions
+
+- **Seam**: 组件渲染输出测试（Vitest + React Testing Library）
+- 验证 className 包含 `min-h-[44px]` 或 `touch-target-expand`
+- 验证视觉尺寸 class（`h-9`、`min-h-[36px]` 等）
+- 验证 `::before` 工具类存在于 `index.css`
+
+## Out of Scope
+
+- 桌面端尺寸调整
+- `headerControlStyles.ts` 全局常量修改
+- `segmented-toggle.tsx` 组件本身修改
+- 卡片间距、圆角等布局微调
+- Metrics 三列网格（非交互）
+
+## Further Notes
+
+- 所有共享组件改动在调用方进行，不改组件本身
+- `touch-target-expand` 放全局 `index.css` 供复用
+- `::before` 的 `pointer-events` 和 `z-index` 在实现时验证

--- a/src/components/dashboard/MobilePortfolioCard.test.tsx
+++ b/src/components/dashboard/MobilePortfolioCard.test.tsx
@@ -134,15 +134,15 @@ describe('MobilePortfolioCard — P0 audit fixes (AAV-1183)', () => {
       expect(removeBtn!.className).toContain('min-w-[44px]');
     });
 
-    it('pill tab buttons have min-h-[44px]', () => {
+    it('pill tab buttons have min-h-[36px] + touch-target-expand (visual 36px, touch 44px via ::before)', () => {
       const entries = [makeEntry('USDC')];
       const { container } = renderCard(entries);
-      const supplyTab = container.querySelector('button[aria-label]')?.parentElement;
       const tabs = Array.from(container.querySelectorAll('button'))
         .filter(b => b.textContent === 'Supply' || b.textContent === 'Borrow');
       expect(tabs.length).toBe(2);
       for (const tab of tabs) {
-        expect(tab.className).toContain('min-h-[44px]');
+        expect(tab.className).toContain('min-h-[36px]');
+        expect(tab.className).toContain('touch-target-expand');
       }
     });
 

--- a/src/components/dashboard/MobilePortfolioCard.tsx
+++ b/src/components/dashboard/MobilePortfolioCard.tsx
@@ -245,7 +245,7 @@ function MobileCard({
           aria-selected={activeTab === 'supply'}
           onClick={() => setActiveTab('supply')}
           className={cn(
-            'flex-1 ds-text-12 font-semibold rounded-md transition-all duration-200 flex items-center justify-center min-h-[44px]',
+            'flex-1 ds-text-12 font-semibold rounded-md transition-all duration-200 flex items-center justify-center min-h-[36px] relative touch-target-expand',
             activeTab === 'supply'
               ? 'bg-card ds-text-emerald-600 ring-1 ds-ring-emerald-500-15 shadow-sm'
               : 'text-muted-foreground active:text-foreground/70',
@@ -259,7 +259,7 @@ function MobileCard({
           aria-selected={activeTab === 'borrow'}
           onClick={() => setActiveTab('borrow')}
           className={cn(
-            'flex-1 ds-text-12 font-semibold rounded-md transition-all duration-200 flex items-center justify-center min-h-[44px]',
+            'flex-1 ds-text-12 font-semibold rounded-md transition-all duration-200 flex items-center justify-center min-h-[36px] relative touch-target-expand',
             activeTab === 'borrow'
               ? 'bg-card ds-text-brand-cyan ring-1 ds-ring-brand-cyan-15 shadow-sm'
               : 'text-muted-foreground active:text-foreground/70',

--- a/src/components/dashboard/PopularTokenChip.tsx
+++ b/src/components/dashboard/PopularTokenChip.tsx
@@ -31,7 +31,7 @@ const PopularTokenChip = memo(function PopularTokenChip({
       type="button"
       onClick={() => onAdd(reserveId)}
       className={cn(
-        'inline-flex h-[var(--ds-chip-h)] items-center gap-1.5 rounded-full border border-border/50 bg-card/70 px-2.5 leading-none',
+        'inline-flex h-[var(--ds-chip-h)] relative touch-target-expand items-center gap-1.5 rounded-full border border-border/50 bg-card/70 px-2.5 leading-none',
         'ds-text-11 font-semibold text-foreground transition-colors duration-200 hover:bg-muted/60',
       )}
       aria-label={`Add ${tokenSymbol} on ${marketName} to portfolio`}

--- a/src/components/dashboard/PortfolioModeToggle.tsx
+++ b/src/components/dashboard/PortfolioModeToggle.tsx
@@ -39,7 +39,7 @@ const PortfolioModeToggle = memo(function PortfolioModeToggle({
     <label
       data-testid="portfolio-mode-toggle"
       className={cn(
-        'flex cursor-pointer select-none items-center gap-1.5',
+        'flex cursor-pointer select-none items-center gap-1.5 min-h-[44px]',
         isMobile && !isPortfolio && 'flex-col gap-0.5',
       )}
       onMouseEnter={handlePrefetch}

--- a/src/components/dashboard/PortfolioModeToggle.tsx
+++ b/src/components/dashboard/PortfolioModeToggle.tsx
@@ -39,7 +39,7 @@ const PortfolioModeToggle = memo(function PortfolioModeToggle({
     <label
       data-testid="portfolio-mode-toggle"
       className={cn(
-        'flex cursor-pointer select-none items-center gap-1.5 min-h-[44px]',
+        'flex cursor-pointer select-none items-center gap-1.5 relative touch-target-expand',
         isMobile && !isPortfolio && 'flex-col gap-0.5',
       )}
       onMouseEnter={handlePrefetch}

--- a/src/components/dashboard/PortfolioPanel.tsx
+++ b/src/components/dashboard/PortfolioPanel.tsx
@@ -378,7 +378,7 @@ const PortfolioPanel = memo(function PortfolioPanel({
                 type="button"
                 onClick={handleWalletSyncClick}
                 disabled={walletLoadState === 'loading'}
-                className={cn(HEADER_CONTROL_ICON_BUTTON_CLASS)}
+                className={cn(HEADER_CONTROL_ICON_BUTTON_CLASS, 'min-h-[44px] min-w-[44px] md:min-h-0 md:min-w-0')}
                 aria-label={walletLoadState === 'loading' ? 'Syncing wallet positions' : 'Force sync wallet positions'}
                 title={walletLoadState === 'loading' ? 'Syncing…' : 'Force sync'}
                 data-testid="wallet-sync-button"
@@ -398,6 +398,7 @@ const PortfolioPanel = memo(function PortfolioPanel({
                 onClick={() => setShowSaveInput((p) => !p)}
                 className={cn(
                   HEADER_CONTROL_ICON_BUTTON_CLASS,
+                'min-h-[44px] min-w-[44px] md:min-h-0 md:min-w-0',
                   showSaveInput && 'bg-muted text-foreground',
                 )}
                 aria-label={showSaveInput ? 'Cancel save' : 'Save snapshot'}
@@ -415,6 +416,7 @@ const PortfolioPanel = memo(function PortfolioPanel({
               onClick={() => setSearchOpen((p) => !p)}
               className={cn(
                 HEADER_CONTROL_ICON_BUTTON_CLASS,
+                'min-h-[44px] min-w-[44px] md:min-h-0 md:min-w-0',
                 searchOpen && 'bg-muted text-foreground',
               )}
               aria-label={searchOpen ? 'Close search' : 'Search tokens'}
@@ -433,6 +435,7 @@ const PortfolioPanel = memo(function PortfolioPanel({
                     title="Clear all"
                     className={cn(
                       HEADER_CONTROL_ICON_BUTTON_CLASS,
+                'min-h-[44px] min-w-[44px] md:min-h-0 md:min-w-0',
                       PORTFOLIO_THEME.trashHoverBg,
                       PORTFOLIO_THEME.trashHoverText,
                     )}
@@ -493,7 +496,7 @@ const PortfolioPanel = memo(function PortfolioPanel({
 
         {/* Search */}
         {searchOpen && (
-          <div className="mb-2.5">
+          <div className="mb-2.5 py-1 md:py-0">
             <input
               ref={searchInputRef}
               value={searchQuery}

--- a/src/components/dashboard/PortfolioTablePrimitives.tsx
+++ b/src/components/dashboard/PortfolioTablePrimitives.tsx
@@ -340,7 +340,7 @@ export function CompactInput({
     : (sideData.inputMode === 'usd' ? '10K' : '100');
 
   return (
-    <div className="flex items-center gap-1 md:gap-0.5">
+    <div className="flex items-center gap-1 md:gap-0.5 py-1 md:py-0">
       <Tooltip>
         <TooltipTrigger asChild>
           <button
@@ -349,7 +349,7 @@ export function CompactInput({
             onClick={handleToggleInputMode}
             className={cn(
               'shrink-0 rounded border border-border/40 bg-muted/60 ds-text-9 font-semibold text-muted-foreground transition-colors active:bg-muted active:text-foreground md:hover:bg-muted md:hover:text-foreground flex items-center justify-center leading-none',
-              'h-11 w-11 px-1 md:h-5 md:w-auto md:px-1',
+              'h-9 w-9 px-1 min-h-[44px] min-w-[44px] md:h-5 md:w-auto md:px-1 md:min-h-0 md:min-w-0',
               tokenPriceInUsd === undefined && 'opacity-40 cursor-not-allowed',
             )}
             aria-label={`Switch to ${sideData.inputMode === 'usd' ? 'token' : 'USD'} input`}
@@ -384,7 +384,7 @@ export function CompactInput({
           inputMode="decimal"
           placeholder={placeholder}
           className={cn(
-            'h-11 md:h-5 w-full min-w-[2rem] rounded ds-text-11 tabular-nums placeholder:text-muted-foreground/40 placeholder:italic',
+            'h-9 md:h-5 w-full min-w-[2rem] rounded ds-text-11 tabular-nums placeholder:text-muted-foreground/40 placeholder:italic',
             hasValue ? 'pl-1.5 pr-4' : 'pl-1.5 pr-1.5',
             cnDsInputSurface(hasValue, inputVariant),
           )}

--- a/src/components/dashboard/ScenarioControls.tsx
+++ b/src/components/dashboard/ScenarioControls.tsx
@@ -259,6 +259,7 @@ const ScenarioControls = memo(forwardRef<ScenarioControlsHandle, ScenarioControl
     return (
       <div className="relative rounded-xl border border-border/60 bg-card/60 backdrop-blur-sm px-1.5 py-1">
         <div className="flex min-w-0 items-center gap-1.5">
+          <div className="py-2 md:py-0">
           <SegmentedToggle
             options={[
               { value: 'usd', label: 'USD' },
@@ -270,7 +271,8 @@ const ScenarioControls = memo(forwardRef<ScenarioControlsHandle, ScenarioControl
             activeTextClassName={segmentedActiveTextClass}
             className="shrink-0 self-stretch"
           />
-          <div className="flex flex-col gap-1 flex-1 min-w-0">
+          </div>
+          <div className="flex flex-col gap-0.5 flex-1 min-w-0 py-1">
             <ScenarioInputField
               side="supply"
               displayValue={supplyInput.displayValue}
@@ -301,7 +303,7 @@ const ScenarioControls = memo(forwardRef<ScenarioControlsHandle, ScenarioControl
               type="button"
               onClick={() => setInternalMobileNetOpen((prev) => !prev)}
               className={cn(
-                'shrink-0 inline-flex h-[var(--ds-control-h)] w-[var(--ds-control-h)] items-center justify-center text-muted-foreground/65 transition-colors',
+                'shrink-0 inline-flex h-[var(--ds-control-h)] w-[var(--ds-control-h)] min-h-[44px] min-w-[44px] items-center justify-center text-muted-foreground/65 transition-colors',
                 mobileNetOpen
                   ? 'text-foreground'
                   : 'hover:text-foreground/85',

--- a/src/index.css
+++ b/src/index.css
@@ -1012,3 +1012,16 @@
     box-shadow: none;
   }
 }
+
+/* Touch target expansion — Pattern C: ::before pseudo-element.
+ * Expands clickable area without changing visual element height.
+ * Usage: add `relative touch-target-expand` to elements that need
+ * larger touch target than their visual size (chips, tabs, switches).
+ * See docs/design/mobile-touch-target-optimization.md §2.2 Pattern C.
+ */
+.touch-target-expand::before {
+  content: '';
+  position: absolute;
+  inset: -8px;
+  pointer-events: auto;
+}


### PR DESCRIPTION
## Summary
- Sync 2 new commits from `lovable` into `dev`: mobile touch target optimization (AAV-1195/1196/1197/1198)
- Previous PR #444 merge lost these changes due to merge direction; this restores lovable as source of truth

## Changes
- `6ec49291` fix(portfolio): switch toggle overflow — min-h to touch-target-expand (AAV-1198)
- `e470219b` feat(mobile): touch target optimization — visual small + touch 44px (AAV-1195/1196/1197/1198)

## Merge Strategy
Merge commit