### PR TITLE
fix: dependabot auto-triage ecosystem name fix

### DIFF
--- a/.github/workflows/dependabot-auto-triage.yml
+++ b/.github/workflows/dependabot-auto-triage.yml
@@ -35,7 +35,7 @@ jobs:
             const ecosystem = process.env.ECOSYSTEM;
             const safeSemver = ['version-update:semver-patch', 'version-update:semver-minor'].includes(updateType);
             const safeNpm = ecosystem === 'npm' && safeSemver && dependencyType === 'direct:development';
-            const safeActions = ecosystem === 'github-actions' && safeSemver;
+            const safeActions = (ecosystem === 'github-actions' || ecosystem === 'github_actions') && safeSemver;
             const safe = safeNpm || safeActions;
 
             const labels = safe


### PR DESCRIPTION
Dependabot returns `github_actions` (underscore) but workflow was checking `github-actions` (hyphen). This caused GitHub Actions patch/minor updates to be incorrectly labeled as `manual-review` instead of `automerge`.