### PR TITLE
fix: AAV-1107 reset minVisibleCount on significant data change

### DIFF
--- a/docs/plans/frontend-triage-2026-06/00-overview.md
+++ b/docs/plans/frontend-triage-2026-06/00-overview.md
@@ -2,7 +2,7 @@
 
 > `docs/plans/frontend-triage-2026-06/`
 
-## 总进度（2026-07-28 更新）
+## 总进度（2026-07-30 更新）
 
 > 这是所有 triage phase 的**唯一状态跟踪源**。每次完成一个 phase 或 issue 后更新此表。
 
@@ -17,7 +17,7 @@
 | ✅ Done | 7 | AAV-1096 | grid→flex 统一完成（commit `103254c5`，子 issue AAV-1234 Done） |
 | 🔄 Shrunk | 8 | AAV-1104/734/1095/783/1141 | AAV-734 Done, AAV-1095 Done, AAV-1104 Canceled（ADR-0027）; 剩 AAV-783（后端）+ AAV-1141（低优先） |
 | ✅ Done | 9 | AAV-1144~1158 | staging API ✅, testid ✅; 25 处 platform-conditional skip → project config routing (AAV-1154 Done) |
-| ✅ Done | 10 | AAV-1107/1084/1121/1114/1113/738 | AAV-1121+1084 fixed; AAV-1107 verified fixed; AAV-1114 not a bug (Canceled); AAV-738 feature request; AAV-1113 no data |
+| ✅ Done | 10 | AAV-1107/1084/1121/1114/1113/738 | AAV-1121+1084 fixed+staged; AAV-1107 verified on staging; AAV-1114 Canceled; AAV-738 Backlog; AAV-1113 Backlog（有数据但代码未满足：每个note是独立`<tr>`，需改为inline） |
 | 📝 Re-eval | 11 | AAV-1136/1135/1123/1122/1110/1102/1162/1160/1159/733 | Portfolio simulation UI — 需重新评估（部分可能已被后续改动覆盖） |
 | ⚠️ Dormant | 12 | AAV-1023/1024 | 阻塞于 AAV-1022（No priority, 自 6/27 无进展）；投入产出比低 |
 | 🔄 Unblocked | 13 | AAV-843 | 阻塞项 AAV-842 已 Canceled；per-user API 独立于 distributedSoFarUsd，可解除阻塞 |
@@ -79,7 +79,7 @@
 |------|-------|-------|------|------|
 | ~~1~~ | ~~9~~ | ~~21 处 platform skip→describe 迁移~~ | ✅ Done (AAV-1154) | ~~0.5 session~~ |
 | ~~1~~ | ~~10~~ | ~~AAV-1107 等~~ | ✅ Done (commit `738a068c`) — AAV-1121+1084 fixed, 1107 verified, 1114 canceled | ~~0.5 session~~ |
-| **2** | 11 | AAV-1136 等 | 📝 Re-eval — 先浏览器验证哪些已被覆盖 | 0.5 session 验证 |
+| **1** | 11 | AAV-1136 等 | 📝 Re-eval — 先浏览器验证哪些已被覆盖 | 0.5 session 验证 |
 | **3** | 13 | AAV-843 | 🔄 Unblocked — 需单独 spec | 2-3 sessions |
 | — | 8 | AAV-1141 | 📉 低优先 — 需先 Lighthouse | 待定 |
 | — | 4 | AAV-756 | ⏸️ Blocked — 等后端 AAV-1222 | — |

--- a/src/hooks/reserves-table/useReservesPagination.test.ts
+++ b/src/hooks/reserves-table/useReservesPagination.test.ts
@@ -171,4 +171,102 @@ describe('useReservesPagination', () => {
       expect(result.current.showAll).toBe(false);
     });
   });
+
+  describe('significant data change resets pagination (AAV-1107)', () => {
+    it('resets minVisibleCount to null when sortedData grows significantly (filter removed)', () => {
+      // Simulate: 30 reserves (Celo filter), expand row 25 (past DEFAULT_VISIBLE_COUNT),
+      // then remove filter → 200 reserves. Auto-grow fired on expand (31 > 20),
+      // but after data change it should reset.
+      const smallData = makeReserves(30);
+      const expandedSimId = smallData[25].reserveId;
+      const { result, rerender } = renderHook(
+        ({ data, expandedId }: { data: ReserveWithSpread[]; expandedId: string | null }) =>
+          useReservesPagination({ sortedData: data, expandedReserveId: expandedId }),
+        { initialProps: { data: smallData, expandedId: null } },
+      );
+
+      // Expand row 25 → auto-grow fires (25+6=31 > DEFAULT_VISIBLE_COUNT=20)
+      rerender({ data: smallData, expandedId: expandedSimId });
+      expect(result.current.minVisibleCount).toBe(30); // capped to 30 (only 30 reserves)
+
+      // Remove filter → 200 reserves (significant change: 30 → 200)
+      const bigData = makeReserves(200);
+      // Keep expandedId the same — expansion is preserved across filter changes
+      rerender({ data: bigData, expandedId: expandedSimId });
+
+      // minVisibleCount should be reset to null (default 20)
+      expect(result.current.minVisibleCount).toBeNull();
+      expect(result.current.displayData).toHaveLength(DEFAULT_VISIBLE_COUNT);
+    });
+
+    it('resets minVisibleCount when sortedData shrinks significantly (filter applied)', () => {
+      const bigData = makeReserves(100);
+      const { result, rerender } = renderHook(
+        ({ data }: { data: ReserveWithSpread[] }) =>
+          useReservesPagination({ sortedData: data, expandedReserveId: null }),
+        { initialProps: { data: bigData } },
+      );
+
+      // Show all → minVisibleCount = 100
+      act(() => result.current.showAllRows());
+      expect(result.current.minVisibleCount).toBe(100);
+
+      // Apply filter → 5 reserves (significant change: 100 → 5)
+      const smallData = makeReserves(5);
+      rerender({ data: smallData });
+      expect(result.current.minVisibleCount).toBeNull();
+      expect(result.current.displayData).toHaveLength(5); // only 5 reserves
+    });
+
+    it('does NOT reset minVisibleCount on small data changes (data refresh)', () => {
+      const data = makeReserves(50);
+      const { result, rerender } = renderHook(
+        ({ d }: { d: ReserveWithSpread[] }) =>
+          useReservesPagination({ sortedData: d, expandedReserveId: null }),
+        { initialProps: { d: data } },
+      );
+
+      // Show all → minVisibleCount = 50
+      act(() => result.current.showAllRows());
+      expect(result.current.minVisibleCount).toBe(50);
+
+      // Small change: 50 → 52 (within threshold, should NOT reset)
+      const refreshed = makeReserves(52);
+      rerender({ d: refreshed });
+      expect(result.current.minVisibleCount).toBe(50); // preserved
+    });
+
+    it('does NOT auto-grow minVisibleCount when sortedData changes under existing expansion', () => {
+      // AAV-1107 core scenario: expand in a filtered view (30 reserves, row 25),
+      // then unfilter to 80 reserves. Auto-grow should NOT re-fire because
+      // expandedReserveId didn't change.
+      const smallData = makeReserves(30);
+      const expandedSimId = smallData[25].reserveId; // index 25
+      const { result, rerender } = renderHook(
+        ({ data, expandedId }: { data: ReserveWithSpread[]; expandedId: string | null }) =>
+          useReservesPagination({ sortedData: data, expandedReserveId: expandedId }),
+        { initialProps: { data: smallData, expandedId: null } },
+      );
+
+      // Expand row 25 → auto-grow fires (25+6=31 > 20)
+      rerender({ data: smallData, expandedId: expandedSimId });
+      expect(result.current.minVisibleCount).toBe(30); // capped to 30 (only 30 reserves)
+
+      // Remove filter → 80 reserves. expandedReserveId is PRESERVED (same value).
+      // The expanded row is now at index 25 in a list of 80 — past the first 20.
+      // minVisibleCount should reset (significant data change), and auto-grow
+      // should NOT re-fire (expandedReserveId didn't change).
+      const bigData = makeReserves(80);
+      // Overwrite index 25's reserveId to match the expanded id
+      (bigData[25] as { reserveId: string }).reserveId = expandedSimId;
+      rerender({ data: bigData, expandedId: expandedSimId });
+
+      // minVisibleCount should be reset to null (significant data change 30→80)
+      expect(result.current.minVisibleCount).toBeNull();
+      // displayData should be the default 20 (not grown to 31)
+      expect(result.current.displayData).toHaveLength(DEFAULT_VISIBLE_COUNT);
+      // The expanded row (index 25) is NOT in displayData (past first 20)
+      // This means renderedExpandedReserveId will be null → no scroll spacer
+    });
+  });
 });

--- a/src/hooks/reserves-table/useReservesPagination.ts
+++ b/src/hooks/reserves-table/useReservesPagination.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import type { ReserveWithSpread } from '@/types/aave';
 import { getReserveKey } from '@/lib/reserveKey';
@@ -85,9 +85,38 @@ export function useReservesPagination(
     }
   }, [sortedData.length, minVisibleCount]);
 
-  // Auto-expand visible count when a row is expanded (persist even after collapse).
+  // Reset minVisibleCount when the dataset changes significantly (e.g., filter
+  // applied/removed). This prevents stale pagination from keeping the scroll
+  // spacer alive when the expanded row is no longer near the bottom of the
+  // visible window (AAV-1107).
+  const prevDataLengthRef = useRef(sortedData.length);
   useEffect(() => {
-    if (!expandedReserveId) return;
+    const prev = prevDataLengthRef.current;
+    const curr = sortedData.length;
+    if (prev === curr) return;
+    prevDataLengthRef.current = curr;
+    if (minVisibleCount === null) return;
+    // Only reset when the dataset changed significantly (> 50% of the larger
+    // value). Small changes (data refresh, single reserve added/removed) should
+    // not reset the user's pagination state.
+    const threshold = Math.max(prev, curr, DEFAULT_VISIBLE_COUNT) * 0.5;
+    if (Math.abs(curr - prev) > threshold) {
+      setMinVisibleCount(null);
+    }
+  }, [sortedData.length]); // eslint-disable-line react-hooks/exhaustive-deps -- minVisibleCount read via closure; only re-run on length change
+
+  // Auto-expand visible count when a row is expanded. Only fires on
+  // user-initiated expansion (expandedReserveId changes), NOT on data changes
+  // under an existing expansion. This prevents the scroll spacer from being
+  // rendered after a filter is removed and the expanded row is deep in the
+  // full list (AAV-1107).
+  const prevExpandedRef = useRef<string | null>(null);
+  useEffect(() => {
+    const prev = prevExpandedRef.current;
+    prevExpandedRef.current = expandedReserveId;
+    // Only auto-grow when expandedReserveId itself changed (user click),
+    // not when sortedData changed under an existing expansion.
+    if (expandedReserveId === prev || expandedReserveId === null) return;
     const expandedIndex = sortedData.findIndex(
       (r) => getReserveSimulationId(r) === expandedReserveId,
     );

--- a/src/lib/userData/aaveV3UserClient.test.ts
+++ b/src/lib/userData/aaveV3UserClient.test.ts
@@ -10,7 +10,15 @@ import {
 } from './aaveV3UserClient'
 import { createClientWithRpcRotation } from './rpcResilience'
 import { AAVE_V3_CHAIN_IDS } from '../aaveChains'
-import { createPublicClient, http } from 'viem'
+import type { createPublicClient } from 'viem'
+
+vi.mock('./chainDiscovery', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./chainDiscovery')>()
+  return {
+    ...actual,
+    getAllRpcUrls: vi.fn().mockReturnValue([]),
+  }
+})
 
 describe('V3_POOL_ADDRESSES', () => {
   it('covers all V3 mainnet chain IDs', () => {

--- a/src/lib/userData/aaveV4UserClient.test.ts
+++ b/src/lib/userData/aaveV4UserClient.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import {
   V4_SPOKE_ADDRESSES,
   V4_HUB_ADDRESSES,
@@ -19,6 +19,11 @@ import { getAllRpcUrls } from './chainDiscovery'
 
 vi.mock('./chainDiscovery', () => ({
   getAllRpcUrls: vi.fn().mockReturnValue([]),
+}))
+
+vi.mock('viem', () => ({
+  createPublicClient: vi.fn(),
+  http: vi.fn(() => 'mocked-transport'),
 }))
 
 describe('AAV-456 Slice 1: V4 address mapping + ABI types', () => {
@@ -329,6 +334,10 @@ describe('AAV-456 Slice 3: getV4UserPositionsAllSpokes', () => {
 })
 
 describe('createClientWithRpcRotation', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it('returns null for chain with no RPC URLs', async () => {
     vi.mocked(getAllRpcUrls).mockReturnValue([])
     const result = await createClientWithRpcRotation(999991)
@@ -337,6 +346,9 @@ describe('createClientWithRpcRotation', () => {
 
   it('returns a client for a known chain', async () => {
     vi.mocked(getAllRpcUrls).mockReturnValue(['https://eth.drpc.org'])
+    vi.mocked(createPublicClient).mockReturnValue({
+      getChainId: vi.fn().mockResolvedValue(1),
+    } as unknown as ReturnType<typeof createPublicClient>)
     const result = await createClientWithRpcRotation(1)
     expect(result).not.toBeNull()
   })

--- a/src/test/architecture-guard.test.ts
+++ b/src/test/architecture-guard.test.ts
@@ -346,3 +346,67 @@ describe('Architecture guard: docs/plans directory structure', () => {
     expect(entries).not.toContain('handoff');
   });
 });
+
+describe('Architecture guard: test files must mock viem for value imports', () => {
+  /**
+   * Prevents flaky CI failures from tests that accidentally make real RPC
+   * network calls via viem's createPublicClient / http transport.
+   *
+   * Rule: if a test file has a *value* import from 'viem' (not `import type`),
+   * it must also call vi.mock('viem') or vi.doMock('viem').
+   *
+   * Type-only imports (`import type { PublicClient } from 'viem'`) are safe —
+   * they are erased at compile time and create no runtime dependency.
+   *
+   * See: AAV-1235 (CI failure from unmocked viem in aaveV4UserClient.test.ts)
+   */
+  const SRC_ROOT = resolve(__dirname, '..');
+
+  function globTestFiles(dir: string): string[] {
+    const results: string[] = [];
+    let entries: string[];
+    try {
+      entries = readdirSync(resolve(SRC_ROOT, dir));
+    } catch {
+      return results;
+    }
+    for (const entry of entries) {
+      const full = resolve(SRC_ROOT, dir, entry);
+      if (statSync(full).isDirectory()) {
+        results.push(...globTestFiles(`${dir}/${entry}`));
+      } else if (entry.endsWith('.test.ts') || entry.endsWith('.test.tsx')) {
+        results.push(`${dir}/${entry}`);
+      }
+    }
+    return results;
+  }
+
+  const TEST_DIRS = ['lib', 'hooks', 'components', 'test', 'providers', 'types', 'config'];
+  const ALL_TEST_FILES = TEST_DIRS.flatMap(globTestFiles);
+
+  for (const file of ALL_TEST_FILES) {
+    it(`${file} mocks viem if it value-imports it`, () => {
+      const src = readFile(file);
+
+      // Find all lines that import from 'viem'
+      const viemImportLines = src.match(/^\s*import\s+.*\bfrom\s*['"]viem['"]/gm) ?? [];
+      if (viemImportLines.length === 0) return;
+
+      // Check if ANY import is a value import (not `import type`)
+      const hasValueImport = viemImportLines.some(
+        (line) => !/^\s*import\s+type\s/.test(line),
+      );
+      if (!hasValueImport) return; // All imports are type-only — safe
+
+      // Value import present — must have a corresponding mock
+      const hasMock = /vi\.(mock|doMock)\s*\(\s*['"]viem['"]/.test(src);
+      expect(
+        hasMock,
+        `${file} has a value import from 'viem' but does not mock it.\n` +
+        'This can cause flaky CI failures from real network calls.\n' +
+        "Fix: add vi.mock('viem', () => ({ createPublicClient: vi.fn(), http: vi.fn() }))\n" +
+        'Or: convert to "import type { ... } from \'viem\'" if only types are needed.',
+      ).toBe(true);
+    });
+  }
+});


### PR DESCRIPTION
fix: AAV-1107 reset minVisibleCount on significant data change

## Changes
- Reset minVisibleCount when sortedData changes significantly (filter applied/removed)
- Auto-grow only fires on user-initiated expansion, not on data changes under existing expansion
- Added 4 new test cases covering the AAV-1107 scenario

## Test coverage gap addressed
- Previous tests only used 2-50 reserves, never simulated filter→expand→unfilter
- New tests use 30→200 and 30→80 reserve transitions
