### PR TITLE
chore(openapi): sync spec + generated schemas from backend (main)

### DIFF
--- a/public/openapi.json
+++ b/public/openapi.json
@@ -492,6 +492,45 @@
                   }
                 ]
               },
+              "crossAssetPairing": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "sourceSide": {
+                        "type": "string",
+                        "enum": [
+                          "supply",
+                          "borrow"
+                        ]
+                      },
+                      "pairedReserveId": {
+                        "type": "string"
+                      },
+                      "pairedSide": {
+                        "type": "string",
+                        "enum": [
+                          "supply",
+                          "borrow"
+                        ]
+                      },
+                      "discountFactor": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "sourceSide",
+                      "pairedReserveId",
+                      "pairedSide",
+                      "discountFactor"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "borrowBlacklist": {
                 "type": "boolean"
               }
@@ -612,6 +651,45 @@
                     "required": [
                       "sourceSide",
                       "offsetReserveIds"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "crossAssetPairing": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "sourceSide": {
+                        "type": "string",
+                        "enum": [
+                          "supply",
+                          "borrow"
+                        ]
+                      },
+                      "pairedReserveId": {
+                        "type": "string"
+                      },
+                      "pairedSide": {
+                        "type": "string",
+                        "enum": [
+                          "supply",
+                          "borrow"
+                        ]
+                      },
+                      "discountFactor": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "sourceSide",
+                      "pairedReserveId",
+                      "pairedSide",
+                      "discountFactor"
                     ],
                     "additionalProperties": false
                   },
@@ -777,6 +855,45 @@
                     "required": [
                       "sourceSide",
                       "offsetReserveIds"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "crossAssetPairing": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "sourceSide": {
+                        "type": "string",
+                        "enum": [
+                          "supply",
+                          "borrow"
+                        ]
+                      },
+                      "pairedReserveId": {
+                        "type": "string"
+                      },
+                      "pairedSide": {
+                        "type": "string",
+                        "enum": [
+                          "supply",
+                          "borrow"
+                        ]
+                      },
+                      "discountFactor": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "sourceSide",
+                      "pairedReserveId",
+                      "pairedSide",
+                      "discountFactor"
                     ],
                     "additionalProperties": false
                   },
@@ -1098,6 +1215,45 @@
               }
             ]
           },
+          "crossAssetPairing": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "sourceSide": {
+                    "type": "string",
+                    "enum": [
+                      "supply",
+                      "borrow"
+                    ]
+                  },
+                  "pairedReserveId": {
+                    "type": "string"
+                  },
+                  "pairedSide": {
+                    "type": "string",
+                    "enum": [
+                      "supply",
+                      "borrow"
+                    ]
+                  },
+                  "discountFactor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "sourceSide",
+                  "pairedReserveId",
+                  "pairedSide",
+                  "discountFactor"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "borrowBlacklist": {
             "type": "boolean"
           }
@@ -1218,6 +1374,45 @@
                 "required": [
                   "sourceSide",
                   "offsetReserveIds"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "crossAssetPairing": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "sourceSide": {
+                    "type": "string",
+                    "enum": [
+                      "supply",
+                      "borrow"
+                    ]
+                  },
+                  "pairedReserveId": {
+                    "type": "string"
+                  },
+                  "pairedSide": {
+                    "type": "string",
+                    "enum": [
+                      "supply",
+                      "borrow"
+                    ]
+                  },
+                  "discountFactor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "sourceSide",
+                  "pairedReserveId",
+                  "pairedSide",
+                  "discountFactor"
                 ],
                 "additionalProperties": false
               },
@@ -1383,6 +1578,45 @@
                 "required": [
                   "sourceSide",
                   "offsetReserveIds"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "crossAssetPairing": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "sourceSide": {
+                    "type": "string",
+                    "enum": [
+                      "supply",
+                      "borrow"
+                    ]
+                  },
+                  "pairedReserveId": {
+                    "type": "string"
+                  },
+                  "pairedSide": {
+                    "type": "string",
+                    "enum": [
+                      "supply",
+                      "borrow"
+                    ]
+                  },
+                  "discountFactor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "sourceSide",
+                  "pairedReserveId",
+                  "pairedSide",
+                  "discountFactor"
                 ],
                 "additionalProperties": false
               },

--- a/src/generated/api/schemas.ts
+++ b/src/generated/api/schemas.ts
@@ -116,6 +116,17 @@ const CampaignGroupApiMeritCampaignBreakdown = z.object({
       z.null(),
     ])
     .optional(),
+  crossAssetPairing: z
+    .union([
+      z.object({
+        sourceSide: z.enum(["supply", "borrow"]),
+        pairedReserveId: z.string(),
+        pairedSide: z.enum(["supply", "borrow"]),
+        discountFactor: z.number(),
+      }),
+      z.null(),
+    ])
+    .optional(),
   borrowBlacklist: z.boolean().optional(),
 });
 const MerklCampaignBreakdown = z.object({
@@ -162,6 +173,17 @@ const ApiMerklOpportunityGroup = z.object({
       z.null(),
     ])
     .optional(),
+  crossAssetPairing: z
+    .union([
+      z.object({
+        sourceSide: z.enum(["supply", "borrow"]),
+        pairedReserveId: z.string(),
+        pairedSide: z.enum(["supply", "borrow"]),
+        discountFactor: z.number(),
+      }),
+      z.null(),
+    ])
+    .optional(),
   borrowBlacklist: z.boolean().optional(),
 });
 const ApiBrevisBreakdown = z.object({
@@ -188,6 +210,17 @@ const CampaignGroupApiBrevisBreakdown = z.object({
       z.object({
         sourceSide: z.enum(["supply", "borrow"]),
         offsetReserveIds: z.array(z.string()),
+      }),
+      z.null(),
+    ])
+    .optional(),
+  crossAssetPairing: z
+    .union([
+      z.object({
+        sourceSide: z.enum(["supply", "borrow"]),
+        pairedReserveId: z.string(),
+        pairedSide: z.enum(["supply", "borrow"]),
+        discountFactor: z.number(),
       }),
       z.null(),
     ])


### PR DESCRIPTION
Auto-generated OpenAPI spec + Zod schema sync.

Trigger: `push` on `main`
The `openapi-check` job detected a spec drift; this PR syncs:
- `public/openapi.json` from the live backend
- `src/generated/api/schemas.ts` via `npm run schema:codegen`

⚠️ Generated code may break compilation — review before merge.