### PR TITLE
chore(openapi): sync spec + generated schemas from backend (lovable)

### DIFF
--- a/public/openapi.json
+++ b/public/openapi.json
@@ -420,6 +420,14 @@
               },
               "collateralRisk": {
                 "type": "number"
+              },
+              "ltv": {
+                "type": "number",
+                "description": "Collateral LTV (percent: 80 = 80%). V3: supplyInfo.maxLTV, V4: settings.collateralFactor."
+              },
+              "liquidationThreshold": {
+                "type": "number",
+                "description": "Liquidation threshold (percent: 82.5 = 82.5%). V3: supplyInfo.liquidationThreshold, V4: = ltv (collateralFactor)."
               }
             },
             "required": [
@@ -476,6 +484,45 @@
                     "required": [
                       "sourceSide",
                       "offsetReserveIds"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "crossAssetPairing": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "sourceSide": {
+                        "type": "string",
+                        "enum": [
+                          "supply",
+                          "borrow"
+                        ]
+                      },
+                      "pairedReserveId": {
+                        "type": "string"
+                      },
+                      "pairedSide": {
+                        "type": "string",
+                        "enum": [
+                          "supply",
+                          "borrow"
+                        ]
+                      },
+                      "discountFactor": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "sourceSide",
+                      "pairedReserveId",
+                      "pairedSide",
+                      "discountFactor"
                     ],
                     "additionalProperties": false
                   },
@@ -604,6 +651,45 @@
                     "required": [
                       "sourceSide",
                       "offsetReserveIds"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "crossAssetPairing": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "sourceSide": {
+                        "type": "string",
+                        "enum": [
+                          "supply",
+                          "borrow"
+                        ]
+                      },
+                      "pairedReserveId": {
+                        "type": "string"
+                      },
+                      "pairedSide": {
+                        "type": "string",
+                        "enum": [
+                          "supply",
+                          "borrow"
+                        ]
+                      },
+                      "discountFactor": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "sourceSide",
+                      "pairedReserveId",
+                      "pairedSide",
+                      "discountFactor"
                     ],
                     "additionalProperties": false
                   },
@@ -769,6 +855,45 @@
                     "required": [
                       "sourceSide",
                       "offsetReserveIds"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "crossAssetPairing": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "sourceSide": {
+                        "type": "string",
+                        "enum": [
+                          "supply",
+                          "borrow"
+                        ]
+                      },
+                      "pairedReserveId": {
+                        "type": "string"
+                      },
+                      "pairedSide": {
+                        "type": "string",
+                        "enum": [
+                          "supply",
+                          "borrow"
+                        ]
+                      },
+                      "discountFactor": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "sourceSide",
+                      "pairedReserveId",
+                      "pairedSide",
+                      "discountFactor"
                     ],
                     "additionalProperties": false
                   },
@@ -1018,6 +1143,14 @@
           },
           "collateralRisk": {
             "type": "number"
+          },
+          "ltv": {
+            "type": "number",
+            "description": "Collateral LTV (percent: 80 = 80%). V3: supplyInfo.maxLTV, V4: settings.collateralFactor."
+          },
+          "liquidationThreshold": {
+            "type": "number",
+            "description": "Liquidation threshold (percent: 82.5 = 82.5%). V3: supplyInfo.liquidationThreshold, V4: = ltv (collateralFactor)."
           }
         },
         "required": [
@@ -1074,6 +1207,45 @@
                 "required": [
                   "sourceSide",
                   "offsetReserveIds"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "crossAssetPairing": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "sourceSide": {
+                    "type": "string",
+                    "enum": [
+                      "supply",
+                      "borrow"
+                    ]
+                  },
+                  "pairedReserveId": {
+                    "type": "string"
+                  },
+                  "pairedSide": {
+                    "type": "string",
+                    "enum": [
+                      "supply",
+                      "borrow"
+                    ]
+                  },
+                  "discountFactor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "sourceSide",
+                  "pairedReserveId",
+                  "pairedSide",
+                  "discountFactor"
                 ],
                 "additionalProperties": false
               },
@@ -1202,6 +1374,45 @@
                 "required": [
                   "sourceSide",
                   "offsetReserveIds"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "crossAssetPairing": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "sourceSide": {
+                    "type": "string",
+                    "enum": [
+                      "supply",
+                      "borrow"
+                    ]
+                  },
+                  "pairedReserveId": {
+                    "type": "string"
+                  },
+                  "pairedSide": {
+                    "type": "string",
+                    "enum": [
+                      "supply",
+                      "borrow"
+                    ]
+                  },
+                  "discountFactor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "sourceSide",
+                  "pairedReserveId",
+                  "pairedSide",
+                  "discountFactor"
                 ],
                 "additionalProperties": false
               },
@@ -1367,6 +1578,45 @@
                 "required": [
                   "sourceSide",
                   "offsetReserveIds"
+                ],
+                "additionalProperties": false
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "crossAssetPairing": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "sourceSide": {
+                    "type": "string",
+                    "enum": [
+                      "supply",
+                      "borrow"
+                    ]
+                  },
+                  "pairedReserveId": {
+                    "type": "string"
+                  },
+                  "pairedSide": {
+                    "type": "string",
+                    "enum": [
+                      "supply",
+                      "borrow"
+                    ]
+                  },
+                  "discountFactor": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "sourceSide",
+                  "pairedReserveId",
+                  "pairedSide",
+                  "discountFactor"
                 ],
                 "additionalProperties": false
               },

--- a/src/generated/api/schemas.ts
+++ b/src/generated/api/schemas.ts
@@ -116,6 +116,17 @@ const CampaignGroupApiMeritCampaignBreakdown = z.object({
       z.null(),
     ])
     .optional(),
+  crossAssetPairing: z
+    .union([
+      z.object({
+        sourceSide: z.enum(["supply", "borrow"]),
+        pairedReserveId: z.string(),
+        pairedSide: z.enum(["supply", "borrow"]),
+        discountFactor: z.number(),
+      }),
+      z.null(),
+    ])
+    .optional(),
   borrowBlacklist: z.boolean().optional(),
 });
 const MerklCampaignBreakdown = z.object({
@@ -162,6 +173,17 @@ const ApiMerklOpportunityGroup = z.object({
       z.null(),
     ])
     .optional(),
+  crossAssetPairing: z
+    .union([
+      z.object({
+        sourceSide: z.enum(["supply", "borrow"]),
+        pairedReserveId: z.string(),
+        pairedSide: z.enum(["supply", "borrow"]),
+        discountFactor: z.number(),
+      }),
+      z.null(),
+    ])
+    .optional(),
   borrowBlacklist: z.boolean().optional(),
 });
 const ApiBrevisBreakdown = z.object({
@@ -188,6 +210,17 @@ const CampaignGroupApiBrevisBreakdown = z.object({
       z.object({
         sourceSide: z.enum(["supply", "borrow"]),
         offsetReserveIds: z.array(z.string()),
+      }),
+      z.null(),
+    ])
+    .optional(),
+  crossAssetPairing: z
+    .union([
+      z.object({
+        sourceSide: z.enum(["supply", "borrow"]),
+        pairedReserveId: z.string(),
+        pairedSide: z.enum(["supply", "borrow"]),
+        discountFactor: z.number(),
       }),
       z.null(),
     ])
@@ -242,6 +275,8 @@ const MarketWithSpread = z.object({
   spokeName: z.string().optional(),
   spokeAddress: z.string().optional(),
   collateralRisk: z.number().optional(),
+  ltv: z.number().optional(),
+  liquidationThreshold: z.number().optional(),
 });
 const ApiMeritCampaignGroup = CampaignGroupApiMeritCampaignBreakdown;
 const ApiMerklBreakdown = MerklCampaignBreakdown;


### PR DESCRIPTION
Auto-generated OpenAPI spec + Zod schema sync.

Trigger: `push` on `lovable`
The `openapi-check` job detected a spec drift; this PR syncs:
- `public/openapi.json` from the live backend
- `src/generated/api/schemas.ts` via `npm run schema:codegen`

⚠️ Generated code may break compilation — review before merge.