### PR TITLE
docs: digest handoff docs into ADR-0029 + conventions

### DIFF
--- a/docs/adr/0029-vercel-auth-bypass-ci-access.md
+++ b/docs/adr/0029-vercel-auth-bypass-ci-access.md
@@ -1,0 +1,79 @@
+# ADR-0029: Vercel Authentication bypass for CI access
+
+## Status
+
+Accepted (2026-08-06)
+
+## Context
+
+Vercel Authentication (`ssoProtection: { enabled: true, deploymentType: "prod_deployment_urls_and_all_previews" }`) was enabled on the Vercel project to prevent unauthorised access to staging and preview deployments. This blocks all requests without a Vercel login session — including CI automation (curl in `deployment-smoke-test.yml`, Playwright in `ci.yml`).
+
+Two independent CI access problems resulted:
+
+1. **Smoke test (`deployment-smoke-test.yml`)**: curl requests to `staging.aaveapy.com` and `*.vercel.app` received the Vercel login page (HTTP 200, but no `#root` element), causing `site_check` and `deploy_url_check` failures.
+
+2. **E2E tests (`ci.yml`)**: Playwright's built app called `staging-api.aaveapy.com` at runtime; Cloudflare WAF (sitting in front of the public domain) returned 403 to GitHub Actions IPs. Additionally, `e2e/test-reserves.ts` fetched the staging API at module load for dynamic reserve discovery — also blocked.
+
+## Decision
+
+Use two complementary bypass strategies, each targeting the correct interception layer:
+
+### 1. Vercel Authentication bypass (frontend pages)
+
+Use Vercel's official **Automation Bypass Secret** (`VERCEL_AUTOMATION_BYPASS_SECRET`):
+
+- Generate via `scripts/generate-vercel-bypass-secret.sh` (calls Vercel REST API).
+- Store as a GitHub Actions encrypted secret.
+- Inject as HTTP header in all curl calls that hit Vercel-served URLs:
+  ```
+  curl -H "x-vercel-protection-bypass: $VERCEL_AUTOMATION_BYPASS_SECRET" ...
+  ```
+- Applied to both `site_check` (custom domain) and `deploy_url_check` (preview URL) steps in `deployment-smoke-test.yml`.
+- When the secret is absent, the workflow logs a warning and continues (graceful degradation).
+
+### 2. Railway direct URL (backend API)
+
+Use the `LIVE_TEST_API_BASE_CI` GitHub secret (Railway internal URL) to route CI API traffic directly to Railway, bypassing Cloudflare entirely:
+
+- CI E2E jobs (`e2e-desktop`, `e2e-mobile`) inject `VITE_API_BASE_URL` from the secret.
+- `build:staging` and `preview:staging` npm scripts use `${VITE_API_BASE_URL:-default}` shell expansion so the CI override is respected.
+- `e2e/test-reserves.ts` reads `process.env.VITE_API_BASE_URL` for its module-load fetch.
+- Local development is unaffected (falls back to `staging-api.aaveapy.com`).
+
+This approach was already used by `live-schema-validation`, `openapi-check`, `hardcode-sync`, and `token-icon-sync` jobs — E2E was the last gap.
+
+## Consequences
+
+### Positive
+
+- CI smoke test and E2E tests pass reliably without Vercel Authentication or Cloudflare interference.
+- No per-deployment API calls needed (bypass secret is project-scoped, does not expire).
+- Local development workflow unchanged.
+- Graceful degradation when secrets are not configured (warnings, not hard failures for smoke test).
+
+### Negative
+
+- Two GitHub secrets must be maintained (`VERCEL_AUTOMATION_BYPASS_SECRET`, `LIVE_TEST_API_BASE_CI`). If either expires or is rotated, CI will fail until updated.
+- The bypass secret is stored in plaintext inside the workflow YAML expression (`${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}`); GitHub masks it in logs, but the workflow file itself is in the repo.
+
+## Alternatives Considered
+
+### Vercel shareable URLs (per-deployment)
+
+Generate a `?_vercel_share=<token>` URL for each deployment via Vercel API. Expires in ~23 hours. Requires a per-deployment API call in CI. Rejected — adds complexity and latency for no benefit over the static bypass secret.
+
+### Disable Vercel Authentication
+
+Rejected. Staging protection is a deliberate security measure. Disabling it would expose unreleased features and staging data to anyone who guesses the URL.
+
+### Cloudflare IP allow-list for GitHub Actions
+
+Rejected. GitHub Actions uses thousands of rotating exit IPs across many ranges. Maintaining an allow-list is fragile and scales poorly. Documented in `docs/conventions/ci-live-schema-cloudflare.md`.
+
+## Related
+
+- `docs/conventions/vercel-deployment-smoke-test.md` — smoke test workflow reference
+- `docs/conventions/api-base-urls.md` — API URL resolution for all layers
+- `docs/conventions/ci-live-schema-cloudflare.md` — Cloudflare WAF bypass strategy (Railway direct URL)
+- `docs/setup-vercel-auth-bypass.md` — step-by-step bypass secret setup guide
+- AGENTS.md § "main Branch Protection" — Layer 3 (content-security-check) and Vercel Authentication

--- a/docs/conventions/api-base-urls.md
+++ b/docs/conventions/api-base-urls.md
@@ -28,7 +28,7 @@ Production traffic in deployed sites is expected to set `VITE_API_BASE_URL` at b
 
 ## GitHub Actions
 
-| Variable (Repository **Secret**) | Injected as job env | Used by |
+| Secret (Repository **Secrets**) | Injected as job env | Used by |
 |-------------------------------------|---------------------|---------|
 | `LIVE_TEST_API_BASE_CI` | `env.LIVE_TEST_API_BASE_CI` or mapped to `LIVE_TEST_API_BASE` / `VITE_API_BASE_URL` in `ci.yml` | Live schema job, `hardcode-drift-check`, `hardcode-sync`, coingecko scripts, **E2E (e2e-desktop, e2e-mobile)** |
 
@@ -37,6 +37,8 @@ If `LIVE_TEST_API_BASE_CI` is **unset**, workflows fall back to **staging** (sam
 ### E2E (Playwright)
 
 CI E2E jobs (`e2e-desktop`, `e2e-mobile`) inject `LIVE_TEST_API_BASE_CI` as `VITE_API_BASE_URL` into the job environment. The `build:staging` and `preview:staging` npm scripts use `${VITE_API_BASE_URL:-…}` shell expansion, so the Railway direct URL is picked up at build time. `e2e/test-reserves.ts` also reads `process.env.VITE_API_BASE_URL` to fetch test reserve data directly from Railway, bypassing Cloudflare.
+
+See ADR-0029 for the full decision record on CI access bypass strategies.
 
 ## Node scripts (`/markets` and similar)
 
@@ -50,5 +52,7 @@ To compare against **production** from a laptop or CI that can reach it, set the
 
 ## Related docs
 
+- [ADR-0029](../adr/0029-vercel-auth-bypass-ci-access.md) — Vercel Authentication bypass + Railway direct URL decision record
 - `docs/conventions/ci-live-schema-cloudflare.md` — Cloudflare / CI access to staging
+- `docs/conventions/vercel-deployment-smoke-test.md` — Smoke test workflow (uses `VERCEL_AUTOMATION_BYPASS_SECRET` for Vercel Auth bypass)
 - `docs/HARDCODE-AND-EXTERNAL-IMPORTS.md` — hardcode sync / drift checks

--- a/docs/conventions/frontend-regression-checklist.md
+++ b/docs/conventions/frontend-regression-checklist.md
@@ -117,6 +117,16 @@ Record:
 
 Treat framework warnings and missing preview-only analytics scripts separately from app regressions. Treat runtime page errors, blank pages, broken layout, and value mismatch as blockers.
 
+## E2E flaky test prevention
+
+CI E2E tests (`playwright.config.ts`, `e2e/` directory) are prone to flakiness from staging data changes, external service unavailability, and timing issues. Follow these rules to prevent flaky tests from accumulating:
+
+1. **Never hardcode staging API values** — use format/structure assertions (e.g., assert a `\d+\.\d{2}%` pattern instead of a specific APR value). Staging data refreshes invalidate hardcoded expectations. Use `e2e/test-reserves.ts` dynamic discovery instead of hardcoding token symbols.
+2. **Set reasonable timeouts** — `test.setTimeout(120_000)` for tests that involve Portfolio setup + large input + staging API round-trips. Default 60s timeout is insufficient for wallet-mode tests.
+3. **Mark external dependencies** — `test.skip` when external services (block explorers, Merkl API) are unreachable. Do not let third-party downtime block CI.
+4. **Use tolerant visual regression** — `toHaveScreenshot(expected, { maxDiffPixelRatio: 0.01 })` instead of pixel-perfect. Font rendering and anti-aliasing differ across CI environments.
+5. **CI E2E uses Railway direct URL** — `VITE_API_BASE_URL` is injected from `LIVE_TEST_API_BASE_CI` secret to bypass Cloudflare/WAF. See ADR-0029 for details.
+
 ## Numeric consistency checks
 
 When the UI shows a combined total and visible breakdowns, verify the display remains internally consistent.

--- a/docs/conventions/vercel-deployment-smoke-test.md
+++ b/docs/conventions/vercel-deployment-smoke-test.md
@@ -20,8 +20,20 @@ Configure in the GitHub repository:
 | `VERCEL_TOKEN` | API token (smoke polling + rollback) |
 | `VERCEL_PROJECT_ID` | Project ID |
 | `VERCEL_TEAM_ID` | Optional; team scope for the token |
+| `VERCEL_AUTOMATION_BYPASS_SECRET` | Bypass Vercel Authentication for CI curl requests (site_check + deploy_url_check) |
 
 If `VERCEL_TOKEN` is missing, the smoke test and rollback steps **skip** (exit 0) with a log message.
+
+If `VERCEL_AUTOMATION_BYPASS_SECRET` is missing, curl requests to Vercel-served URLs will receive the Vercel Authentication login page instead of the SPA, causing `site_check` and `deploy_url_check` failures. The workflow logs a warning but does not hard-fail on missing secret — the curl failure itself is the signal. See ADR-0029 for the full rationale.
+
+### How the bypass works
+
+Both `site_check` and `deploy_url_check` steps construct a `BYPASS_HEADER` from the secret:
+```bash
+BYPASS_HEADER="-H x-vercel-protection-bypass:${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}"
+curl -L $BYPASS_HEADER "$SITE_URL"
+```
+Vercel recognises the `x-vercel-protection-bypass` header and skips the Authentication interstitial, returning the actual SPA HTML. Setup steps: `docs/setup-vercel-auth-bypass.md`.
 
 ## Deploy SHA verification
 
@@ -58,3 +70,5 @@ When editing rollback logic, **do not** compare these fields as raw strings with
 ## Related docs
 
 - [`api-base-urls.md`](./api-base-urls.md) — API URLs for apps and CI scripts (separate from this Vercel workflow).
+- [ADR-0029](../adr/0029-vercel-auth-bypass-ci-access.md) — Vercel Authentication bypass + Railway direct URL decision record.
+- [`setup-vercel-auth-bypass.md`](../setup-vercel-auth-bypass.md) — Step-by-step bypass secret generation guide.


### PR DESCRIPTION
Digests two handoff documents (both already removed from HEAD) into canonical documentation. ADR-0029 records the Vercel Auth bypass + Railway direct URL decision; conventions updated with bypass secret docs, E2E Railway section, and flaky prevention rules.