### PR TITLE
ci: exempt Dependabot from branch-flow-guard

### DIFF
--- a/.github/workflows/branch-flow-guard.yml
+++ b/.github/workflows/branch-flow-guard.yml
@@ -20,6 +20,10 @@ permissions:
 jobs:
   enforce-dev-to-main:
     name: branch-flow-guard
+    # Dependabot security updates target main directly (beyond our control).
+    # They only bump dependency versions — no code changes that need the
+    # lovable → dev → main flow. CI still runs lint/build/e2e on these PRs.
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Check PR source branch


### PR DESCRIPTION
Dependabot security updates (npm_and_yarn) target main directly, which triggers branch-flow-guard failure. This PR exempts Dependabot PRs from the branch-flow-guard check since they only bump dependency versions — no code changes that need the lovable → dev → main flow. CI (lint/build/e2e) still runs on these PRs. Context: PR #522 CI failed on branch-flow-guard.