### PR TITLE
fix: redirect npm Dependabot security PRs to dev + bump postcss/fast-uri

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,16 @@
-# npm: 由 hardcode-sync CI 统一管理（每日 npm update address-book + sync），不需要 Dependabot 开 PR。
-# Security updates 仍可在 Repo → Settings → Code security 中单独启用。
+# npm regular updates: 由 hardcode-sync CI 统一管理（每日 npm update address-book + sync）。
+# npm security updates: 通过 Dependabot security updates（Repo → Settings → Code security）启用。
+#   target-branch: dev 确保 security PR 走 dev → main 标准流程，避免 branch-flow-guard 失败。
+#   open-pull-requests-limit: 0 阻止 regular version update PR，只允许 security update PR。
 version: 2
 updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    target-branch: dev
+    open-pull-requests-limit: 0
+
   - package-ecosystem: github-actions
     directory: "/"
     schedule:

--- a/package-lock.json
+++ b/package-lock.json
@@ -104,7 +104,7 @@
         "lovable-tagger": "^1.3.1",
         "openapi-zod-client": "^1.18.3",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.10",
+        "postcss": "^8.5.26",
         "rollup": "^4.60.0",
         "tailwindcss": "^3.4.17",
         "typescript": "^5.8.3",
@@ -7197,9 +7197,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -9512,9 +9512,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -10058,9 +10058,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.18",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
-      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -10078,7 +10078,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
     "lovable-tagger": "^1.3.1",
     "openapi-zod-client": "^1.18.3",
     "picomatch": "^4.0.4",
-    "postcss": "^8.5.10",
+    "postcss": "^8.5.26",
     "rollup": "^4.60.0",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.8.3",


### PR DESCRIPTION
## Problem

Dependabot security PRs for npm packages (like #522) target `main` by default because `.github/dependabot.yml` had no npm ecosystem config entry. This causes `branch-flow-guard` (Layer 5) to fail — only `dev -> main` PRs are allowed to merge into `main`.

## Fix

### 1. Dependabot config (`dependabot.yml`)
Add npm ecosystem entry with:
- `target-branch: dev` — security PRs will target `dev` instead of `main`
- `open-pull-requests-limit: 0` — blocks regular version update PRs (still managed by hardcode-sync CI); security updates are unaffected by this limit

### 2. Dependency bumps (from closed PR #522)
- `postcss`: 8.5.18 -> 8.5.26
- `fast-uri`: 3.1.4 -> 3.1.5 (security fix: GHSA-7p8r-x3mc-p8w7)
- `nanoid`: 3.3.16 -> 3.3.17 (transitive, via postcss)

## Closes
- Supersedes #522 (closed — Dependabot could not retarget to `dev`)
